### PR TITLE
Floats

### DIFF
--- a/bootstrap/bootstrap_x86_64_linux.yasm
+++ b/bootstrap/bootstrap_x86_64_linux.yasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce6848b4bed40a90e234faf9343389c460432b55a8d2a6857c5ab9604502287d
-size 568100
+oid sha256:b8c5d047238d3e23dc64ea6ba3f9f732f4adf2d5adedbdcd995fd50f1c562099
+size 616707

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -539,6 +539,13 @@ function is_binary_op(type: NodeType): bool {
 	);
 }
 
+function is_float_arithmetic(type: NodeType): bool {
+	when(type) {
+		NodeType::ADD, NodeType::SUB, NodeType::MUL, NodeType::DIV -> return true;
+	}
+	return false;
+}
+
 function print_ast_depth(node: Node*, depth: int) {
 	for(var i = 0; i < depth; ++i) puts("  ");
 

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -40,6 +40,7 @@ enum NodeType {
 	RELATIVE,
 	INT_LITERAL,
 	CHAR_LITERAL,
+	FLOAT_LITERAL,
 	STRING,
 	CALL,
 	CALL_METHOD,
@@ -176,6 +177,10 @@ struct Node {
 				string: struct {
 					chars: i8*;
 					length: int;
+					id: int;
+				};
+				float: struct {
+					str: i8*;
 					id: int;
 				};
 			};

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -546,6 +546,13 @@ function is_float_arithmetic(type: NodeType): bool {
 	return false;
 }
 
+function is_comparison(type: NodeType): bool {
+	when(type) {
+		NodeType::EQUAL, NodeType::NOT_EQUAL, NodeType::LESS, NodeType::LESS_EQ, NodeType::GREATER, NodeType::GREATER_EQ -> return true;
+	}
+	return false;
+}
+
 function print_ast_depth(node: Node*, depth: int) {
 	for(var i = 0; i < depth; ++i) puts("  ");
 

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -34,6 +34,8 @@ enum NodeType {
 	PRE_DECREMENT,
 	POST_INCREMENT,
 	POST_DECREMENT,
+	INT_TO_FLOAT,
+	FLOAT_TO_INT,
 
 	RELATIVE,
 	INT_LITERAL,
@@ -75,6 +77,7 @@ enum DataType {
 	I16,
 	I32,
 	I64,
+	F64,
 	ANY,
 	STRUCT,
 	UNION,
@@ -368,6 +371,7 @@ function data_type_to_string(type: DataType): i8* {
 		DataType::I16 -> return "i16";
 		DataType::I32 -> return "i32";
 		DataType::I64 -> return "i64";
+		DataType::F64 -> return "f64";
 		DataType::ANY -> return "any";
 		DataType::ALIAS, DataType::UNRESOLVED, DataType::STRUCT, DataType::UNION -> {
 			eputsln("Unreachable - data_type_to_string");
@@ -466,6 +470,8 @@ function node_type_to_string(type: NodeType): i8* {
 		NodeType::PRE_DECREMENT -> return "--";
 		NodeType::POST_INCREMENT -> return "++";
 		NodeType::POST_DECREMENT -> return "--";
+		NodeType::INT_TO_FLOAT -> return "int to float";
+		NodeType::FLOAT_TO_INT -> return "float to int";
 		NodeType::INT_LITERAL -> return "int literal";
 		NodeType::CHAR_LITERAL -> return "char literal";
 		NodeType::STRING -> return "string";

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -641,6 +641,9 @@ function generate_expr_rax(expr: Node*, out: File*) {
 		NodeType::CHAR_LITERAL -> {
 			out.puts("    mov rax, "); out.putd(expr.literal.az.integer); out.putln();
 		}
+		NodeType::FLOAT_LITERAL -> {
+			out.puts("    movsd xmm0, [_D"); out.putd(expr.literal.az.float.id); out.putsln("]");
+		}
 		NodeType::STRING -> {
 			out.puts("    lea rax, [_S"); out.putd(expr.literal.az.string.id); out.putsln("]");
 		}
@@ -1107,6 +1110,12 @@ function Parser.generate_program(ast: Node*, out: File*) {
 
 			out.puts("_S"); out.putd(str.literal.az.string.id); out.puts(": db "); out.putc('"'); out.puts(str.literal.az.string.chars);
 			out.putc('"'); out.putsln(", 0");
+		}
+
+		for(var i = 0; i < this.floats.size; ++i) {
+			var float: Node* = this.floats.at(i);
+
+			out.puts("_D"); out.putd(float.literal.az.float.id); out.puts(": dq "); out.putsln(float.literal.az.float.str);
 		}
 	}
 }

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -458,10 +458,13 @@ function generate_access_subscript(expr: Node*, out: File*) {
 	out.putsln("    mov rcx, rax");
 	out.putsln("    pop rax");
 
-	//TODO F64
-
-	out.puts("    "); out.puts(expr.computedType.movzx()); out.puts(" "); out.puts(expr.computedType.movzx_rax_subregister());
-	out.puts(", "); out.puts(expr.computedType.qualifier()); out.puts(" [rax+rcx*"); out.putd(expr.computedType.size()); out.putsln("]");
+	if(expr.computedType.is_float()) {
+		out.putsln("    movsd xmm0, [rax+rcx*8]");
+	}
+	else {
+		out.puts("    "); out.puts(expr.computedType.movzx()); out.puts(" "); out.puts(expr.computedType.movzx_rax_subregister());
+		out.puts(", "); out.puts(expr.computedType.qualifier()); out.puts(" [rax+rcx*"); out.putd(expr.computedType.size()); out.putsln("]");
+	}
 }
 
 function generate_access_member(expr: Node*, out: File*) {

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -3,9 +3,13 @@ import "std/io.zpr";
 import "std/math.zpr";
 import "src/ast.zpr";
 
-var cg_ARG_REGISTERS: i8*[6] = [ "rdi", "rsi", "rdx", "rcx", "r8", "r9" ];
+const INT_ARG_COUNT = 6;
+const FLOAT_ARG_COUNT = 6;
+var cg_INT_ARG_REGISTERS: i8*[INT_ARG_COUNT] = [ "rdi", "rsi", "rdx", "rcx", "r8", "r9" ];
+var cg_FLOAT_ARG_REGISTERS: i8*[FLOAT_ARG_COUNT] = [ "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7" ];
 var cg_lableCount = 0;
-var cg_registersInUse = 0;
+var cg_intRegistersInUse = 0;
+var cg_floatRegistersInUse = 0;
 var cg_continueLabel = 0;
 var cg_breakLabel = 0;
 
@@ -55,6 +59,18 @@ function Type.reserve(): i8* {
 
 	// Structs are interpreted as pointers which are 8 bytes
 	return "resq";
+}
+
+function Node.expr_type(): Type* {
+	if(this.type == NodeType::SIZEOF) {
+		return INT_TYPE;
+	}
+	else if(this.type == NodeType::ADDROF) {
+		var indr = copy_type(this.unary.computedType);
+		indr.indirection++;
+		return indr;
+	}
+	return this.computedType;
 }
 
 function cmp_suffix(type: int): i8* {
@@ -203,7 +219,8 @@ function generate_binary_float_arith(expr: Node*, out: File*) {
 		}
 	}
 
-	out.puts("    "); out.puts(op); out.putsln(" xmm0, xmm1");
+	out.puts("    "); out.puts(op); out.putsln(" xmm1, xmm0");
+	out.putsln("    movsd xmm0, xmm1");
 }
 
 function generate_binary_rax(expr: Node*, out: File*) {
@@ -276,48 +293,77 @@ function generate_binary_rax(expr: Node*, out: File*) {
 }
 
 function generate_call_rax(expr: Node*, out: File*) {
-	for(var i = 0; i < cg_registersInUse; ++i) {
-		out.puts("    push "); out.putsln(cg_ARG_REGISTERS[i]);
+	for(var i = 0; i < cg_intRegistersInUse; ++i) {
+		out.puts("    push "); out.putsln(cg_INT_ARG_REGISTERS[i]);
+	}
+	for(var i = 0; i < cg_floatRegistersInUse; ++i) {
+		out.putsln("    sub rsp, 8");
+		out.puts("    movsd [rsp], "); out.putsln(cg_FLOAT_ARG_REGISTERS[i]);
 	}
 
-	var localRegUse = 0;
+	var localIntRegUse = 0;
+	var localFloatRegUse = 0;
 
-	for(var i = 0; i < min(expr.funktion.arguments.size, 6); ++i) {
-		generate_expr_rax(expr.funktion.arguments.at(i), out);
-		out.puts("    mov "); out.puts(cg_ARG_REGISTERS[i]); out.putsln(", rax");
-		cg_registersInUse = cg_registersInUse + 1;
-		localRegUse = localRegUse + 1;
+	for(var i = 0; i < expr.funktion.arguments.size; ++i) {
+		var arg: Node* = expr.funktion.arguments.at(i);
+
+		if(arg.expr_type().is_float()) {
+			if(localFloatRegUse < FLOAT_ARG_COUNT) {
+				generate_expr_rax(arg, out);
+				out.puts("    movsd "); out.puts(cg_FLOAT_ARG_REGISTERS[localFloatRegUse]); out.putsln(", xmm0");
+				++cg_floatRegistersInUse;
+				++localFloatRegUse;
+			}
+			else {
+				generate_expr_rax(arg, out);
+				out.putsln("    sub rsp, 8");
+				out.putsln("    movsd [rsp], xmm0");
+			}
+		}
+		else {
+			if(localIntRegUse < INT_ARG_COUNT) {
+				generate_expr_rax(arg, out);
+				out.puts("    mov "); out.puts(cg_INT_ARG_REGISTERS[localIntRegUse]); out.putsln(", rax");
+				++cg_intRegistersInUse;
+				++localIntRegUse;
+			}
+			else {
+				generate_expr_rax(arg, out);
+				out.putsln("    push rax");
+			}
+		}
 	}
 
-	for(var i = 0; i < expr.funktion.arguments.size - 6; ++i) {
-		generate_expr_rax(expr.funktion.arguments.at(i + 6), out);
-		out.putsln("    push rax");
-	}
-
-	cg_registersInUse = cg_registersInUse - localRegUse;
+	cg_intRegistersInUse -= localIntRegUse;
+	cg_floatRegistersInUse -= localFloatRegUse;
 
 	out.puts("    call _F"); out.put_name(&expr.funktion.name); out.putln();
 
-	for(var i = 0; i < cg_registersInUse; ++i) {
-		out.puts("    pop "); out.putsln(cg_ARG_REGISTERS[cg_registersInUse - i - 1]);
+	for(var i = 0; i < cg_intRegistersInUse; ++i) {
+		out.puts("    pop "); out.putsln(cg_INT_ARG_REGISTERS[cg_intRegistersInUse - i - 1]);
+	}
+
+	for(var i = 0; i < cg_floatRegistersInUse; ++i) {
+		out.puts("    movsd "); out.puts(cg_FLOAT_ARG_REGISTERS[cg_floatRegistersInUse - i - 1]); out.putsln(", [rsp]");
+		out.putsln("    add rsp, 8");
 	}
 }
 
 function generate_call_method_rax(expr: Node*, out: File*) {
-	for(var i = 0; i < cg_registersInUse; ++i) {
-		out.puts("    push "); out.putsln(cg_ARG_REGISTERS[i]);
+	for(var i = 0; i < cg_intRegistersInUse; ++i) {
+		out.puts("    push "); out.putsln(cg_INT_ARG_REGISTERS[i]);
 	}
 
 	var localRegUse = 1;
-	cg_registersInUse = cg_registersInUse + 1;
+	cg_intRegistersInUse = cg_intRegistersInUse + 1;
 	
 	generate_expr_rax(expr.funktion.parent, out);
 	out.putsln("    mov rdi, rax");
 
 	for(var i = 0; i < min(expr.funktion.arguments.size, 5); ++i) {
 		generate_expr_rax(expr.funktion.arguments.at(i), out);
-		out.puts("    mov "); out.puts(cg_ARG_REGISTERS[i + 1]); out.putsln(", rax");
-		cg_registersInUse = cg_registersInUse + 1;
+		out.puts("    mov "); out.puts(cg_INT_ARG_REGISTERS[i + 1]); out.putsln(", rax");
+		cg_intRegistersInUse = cg_intRegistersInUse + 1;
 		localRegUse = localRegUse + 1;
 	}
 
@@ -326,13 +372,13 @@ function generate_call_method_rax(expr: Node*, out: File*) {
 		out.putsln("    push rax");
 	}
 
-	cg_registersInUse = cg_registersInUse - localRegUse;
+	cg_intRegistersInUse = cg_intRegistersInUse - localRegUse;
 
 	out.puts("    call _M"); out.put_name(&expr.funktion.parentType.name); out.puts("_"); out.put_name(&expr.funktion.name);
 	out.putln();
 
-	for(var i = 0; i < cg_registersInUse; ++i) {
-		out.puts("    pop "); out.putsln(cg_ARG_REGISTERS[cg_registersInUse - i - 1]);
+	for(var i = 0; i < cg_intRegistersInUse; ++i) {
+		out.puts("    pop "); out.putsln(cg_INT_ARG_REGISTERS[cg_intRegistersInUse - i - 1]);
 	}
 }
 
@@ -583,7 +629,7 @@ function generate_expr_rax(expr: Node*, out: File*) {
 		}
 		NodeType::FLOAT_TO_INT -> {
 			generate_expr_rax(expr.unary, out);
-			out.putsln("    cvtsd2si rax, xmm0");
+			out.putsln("    cvttsd2si rax, xmm0");
 		}
 		else -> {
 			eputs("Unsupported type in generate_expr_rax - "); eputs(node_type_to_string(expr.type)); eputln();
@@ -827,13 +873,35 @@ function generate_function(funktion: Node*, out: File*) {
 		out.puts("    sub rsp, "); out.putd(stackDepth); out.putln();
 	}
 
-	for(var i = 0; i < min(funktion.funktion.arguments.size, 6); ++i) {
-		out.puts("    mov QWORD [rbp-"); out.putd((funktion.funktion.arguments.at(i) as Node*).variable.stackOffset); out.puts("], "); out.putsln(cg_ARG_REGISTERS[i]);
-	}
+	var intRegUse = 0;
+	var floatRegUse = 0;
+	var stackUse = 0;
 
-	for(var i = 0; i < funktion.funktion.arguments.size - 6; ++i) {
-		out.puts("    mov rax, QWORD [rbp+"); out.putd(8 + (8 * (funktion.funktion.arguments.size - 6 - i))); out.putsln("]");
-		out.puts("    mov QWORD [rbp-"); out.putd((funktion.funktion.arguments.at(i + 6) as Node*).variable.stackOffset); out.putsln("], rax");
+	for(var i = 0; i < funktion.funktion.arguments.size; ++i) {
+		var arg: Node* = funktion.funktion.arguments.at(i);
+
+		if(arg.variable.type.is_float()) {
+			if(floatRegUse < FLOAT_ARG_COUNT) {
+				out.puts("    movsd [rbp-"); out.putd(arg.variable.stackOffset); out.puts("], "); out.putsln(cg_FLOAT_ARG_REGISTERS[floatRegUse]);
+				++floatRegUse;
+			}
+			else {
+				out.puts("    movsd xmm0, [rbp+"); out.putd(8 + (8 * (funktion.funktion.arguments.size - (intRegUse + floatRegUse) - stackUse))); out.putsln("]");
+				out.puts("    movsd [rbp-"); out.putd(arg.variable.stackOffset); out.putsln("], xmm0");
+				++stackUse;
+			}
+		}
+		else {
+			if(intRegUse < INT_ARG_COUNT) {
+				out.puts("    mov QWORD [rbp-"); out.putd(arg.variable.stackOffset); out.puts("], "); out.putsln(cg_INT_ARG_REGISTERS[intRegUse]);
+				++intRegUse;
+			}
+			else {
+				out.puts("    mov rax, QWORD [rbp+"); out.putd(8 + (8 * (funktion.funktion.arguments.size - (intRegUse + floatRegUse) - stackUse))); out.putsln("]");
+				out.puts("    mov QWORD [rbp-"); out.putd(arg.variable.stackOffset); out.putsln("], rax");
+				++stackUse;
+			}
+		}
 	}
 
 	generate_block(funktion.funktion.body, out);

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -121,7 +121,14 @@ function generate_unary_rax(expr: Node*, out: File*) {
 		}
 		NodeType::NEG -> {
 			generate_expr_rax(expr.unary, out);
-			out.putsln("    neg rax");
+			if(expr.computedType.is_float()) {
+				out.putsln("    xorps xmm1, xmm1");
+				out.putsln("    subps xmm1, xmm0");
+				out.putsln("    movsd xmm0, xmm1");
+			}
+			else {
+				out.putsln("    neg rax");
+			}
 		}
 		NodeType::NOT -> {
 			generate_expr_rax(expr.unary, out);
@@ -168,6 +175,37 @@ function generate_logical_and_rax(expr: Node*, out: File*) {
 	out.puts(".l"); out.putd(label); out.putsln(":");
 }
 
+function generate_binary_float_arith(expr: Node*, out: File*) {
+	generate_expr_rax(expr.binary.lhs, out);
+	out.putsln("    sub rsp, 8");
+	out.putsln("    movsd [rsp], xmm0");
+	generate_expr_rax(expr.binary.rhs, out);
+	out.putsln("    movsd xmm1, [rsp]");
+	out.putsln("    add rsp, 8");
+
+	var op: i8*;
+	when(expr.type) {
+		NodeType::ADD -> {
+			op = "addsd";
+		}
+		NodeType::SUB -> {
+			op = "subsd";
+		}
+		NodeType::MUL -> {
+			op = "mulsd";
+		}
+		NodeType::DIV -> {
+			op = "divsd";
+		}
+		else -> {
+			eputsln("Unreachable - generate_binary_float_arith");
+			exit(1);
+		}
+	}
+
+	out.puts("    "); out.puts(op); out.putsln(" xmm0, xmm1");
+}
+
 function generate_binary_rax(expr: Node*, out: File*) {
 	if(expr.type == NodeType::OR) {
 		generate_logical_or_rax(expr, out);
@@ -175,6 +213,13 @@ function generate_binary_rax(expr: Node*, out: File*) {
 	}
 	else if(expr.type == NodeType::AND) {
 		generate_logical_and_rax(expr, out);
+		return;
+	}
+
+	if(expr.computedType.is_float()) {
+		assert(is_float_arithmetic(expr.type), "Invalid floating point operation in generate_binary");
+
+		generate_binary_float_arith(expr, out);
 		return;
 	}
 
@@ -419,6 +464,9 @@ function generate_assign_rax(expr: Node*, out: File*) {
 	if(expr.computedType.is_structural()) {
 		generate_copy(expr.computedType.fields, 0, out);
 	}
+	else if(expr.computedType.is_float()) {
+		out.putsln("    movsd [rcx], xmm0");
+	}
 	else {
 		out.puts("    mov "); out.puts(expr.computedType.qualifier()); out.puts(" [rcx], "); out.putsln(expr.computedType.rax_subregister());
 	}
@@ -510,7 +558,12 @@ function generate_expr_rax(expr: Node*, out: File*) {
 			generate_assign_rax(expr, out);
 		}
 		NodeType::RELATIVE -> {
-			out.putsln("    mov rax, [rax]");
+			if(expr.computedType.is_float()) {
+				out.putsln("    movsd xmm0, [rax]");
+			}
+			else {
+				out.putsln("    mov rax, [rax]");
+			}
 		}
 		NodeType::PRE_INCREMENT -> {
 			generate_pre_increment(expr, out);

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -353,32 +353,61 @@ function generate_call_method_rax(expr: Node*, out: File*) {
 	for(var i = 0; i < cg_intRegistersInUse; ++i) {
 		out.puts("    push "); out.putsln(cg_INT_ARG_REGISTERS[i]);
 	}
+	for(var i = 0; i < cg_floatRegistersInUse; ++i) {
+		out.putsln("    sub rsp, 8");
+		out.puts("    movsd [rsp], "); out.putsln(cg_FLOAT_ARG_REGISTERS[i]);
+	}
 
-	var localRegUse = 1;
-	cg_intRegistersInUse = cg_intRegistersInUse + 1;
+	var localIntRegUse = 1;
+	var localFloatRegUse = 0;
+	++cg_intRegistersInUse;
 	
 	generate_expr_rax(expr.funktion.parent, out);
 	out.putsln("    mov rdi, rax");
 
-	for(var i = 0; i < min(expr.funktion.arguments.size, 5); ++i) {
-		generate_expr_rax(expr.funktion.arguments.at(i), out);
-		out.puts("    mov "); out.puts(cg_INT_ARG_REGISTERS[i + 1]); out.putsln(", rax");
-		cg_intRegistersInUse = cg_intRegistersInUse + 1;
-		localRegUse = localRegUse + 1;
+	for(var i = 0; i < expr.funktion.arguments.size; ++i) {
+		var arg: Node* = expr.funktion.arguments.at(i);
+
+		if(arg.expr_type().is_float()) {
+			if(localFloatRegUse < FLOAT_ARG_COUNT) {
+				generate_expr_rax(arg, out);
+				out.puts("    movsd "); out.puts(cg_FLOAT_ARG_REGISTERS[localFloatRegUse]); out.putsln(", xmm0");
+				++cg_floatRegistersInUse;
+				++localFloatRegUse;
+			}
+			else {
+				generate_expr_rax(arg, out);
+				out.putsln("    sub rsp, 8");
+				out.putsln("    movsd [rsp], xmm0");
+			}
+		}
+		else {
+			if(localIntRegUse < INT_ARG_COUNT) {
+				generate_expr_rax(arg, out);
+				out.puts("    mov "); out.puts(cg_INT_ARG_REGISTERS[localIntRegUse]); out.putsln(", rax");
+				++cg_intRegistersInUse;
+				++localIntRegUse;
+			}
+			else {
+				generate_expr_rax(arg, out);
+				out.putsln("    push rax");
+			}
+		}
 	}
 
-	for(var i = 0; i < expr.funktion.arguments.size - 5; ++i) {
-		generate_expr_rax(expr.funktion.arguments.at(i + 5), out);
-		out.putsln("    push rax");
-	}
-
-	cg_intRegistersInUse = cg_intRegistersInUse - localRegUse;
+	cg_intRegistersInUse -= localIntRegUse;
+	cg_floatRegistersInUse -= localFloatRegUse;
 
 	out.puts("    call _M"); out.put_name(&expr.funktion.parentType.name); out.puts("_"); out.put_name(&expr.funktion.name);
 	out.putln();
 
 	for(var i = 0; i < cg_intRegistersInUse; ++i) {
 		out.puts("    pop "); out.putsln(cg_INT_ARG_REGISTERS[cg_intRegistersInUse - i - 1]);
+	}
+
+	for(var i = 0; i < cg_floatRegistersInUse; ++i) {
+		out.puts("    movsd "); out.puts(cg_FLOAT_ARG_REGISTERS[cg_floatRegistersInUse - i - 1]); out.putsln(", [rsp]");
+		out.putsln("    add rsp, 8");
 	}
 }
 
@@ -429,6 +458,8 @@ function generate_access_subscript(expr: Node*, out: File*) {
 	out.putsln("    mov rcx, rax");
 	out.putsln("    pop rax");
 
+	//TODO F64
+
 	out.puts("    "); out.puts(expr.computedType.movzx()); out.puts(" "); out.puts(expr.computedType.movzx_rax_subregister());
 	out.puts(", "); out.puts(expr.computedType.qualifier()); out.puts(" [rax+rcx*"); out.putd(expr.computedType.size()); out.putsln("]");
 }
@@ -439,6 +470,9 @@ function generate_access_member(expr: Node*, out: File*) {
 	
 	if(field.variable.type.isArray || field.variable.type.is_structural()) {
 		out.puts("    lea rax, [rax+"); out.putd(field.variable.stackOffset); out.putsln("]");
+	}
+	else if(field.variable.type.is_float()) {
+		out.puts("    movsd xmm0, [rax+"); out.putd(field.variable.stackOffset); out.putsln("]");
 	}
 	else {
 		out.puts("    "); out.puts(field.variable.type.movzx()); out.puts(" "); out.puts(field.variable.type.movzx_rax_subregister());
@@ -498,7 +532,6 @@ function generate_lvalue_rax(expr: Node*, out: File*) {
 }
 
 function generate_assign_rax(expr: Node*, out: File*) {
-	//TODO: F64
 	generate_lvalue_rax(expr.assignment.lhs, out);
 	out.putsln("    push rax");
 	if(expr.assignment.op.type != TokenType::EQ) {

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -67,7 +67,7 @@ function cmp_suffix(type: int): i8* {
 		NodeType::GREATER_EQ -> return "ge";
 	}
 
-	eputs("Unsupported type in generate_unary_rax - "); eputs(node_type_to_string(type)); eputln();
+	eputs("Unsupported type in cmp_suffix - "); eputs(node_type_to_string(type)); eputln();
 	exit(1);
 	return null;
 }
@@ -312,6 +312,10 @@ function generate_access_var(expr: Node*, out: File*) {
 		out.puts("    lea rax, [rbp-"); out.putd(expr.variable.stackOffset); out.putsln("]");
 		return;
 	}
+	else if(expr.variable.type.is_float()) {
+		out.puts("    movsd xmm0, [rbp-"); out.putd(expr.variable.stackOffset); out.putsln("]");
+		return;
+	}
 
 	out.puts("    "); out.puts(expr.variable.type.movzx()); out.puts(" "); out.puts(expr.variable.type.movzx_rax_subregister()); out.puts(", ");
 	out.puts(expr.variable.type.qualifier()); out.puts(" [rbp-"); out.putd(expr.variable.stackOffset); out.putsln("]");
@@ -403,6 +407,7 @@ function generate_lvalue_rax(expr: Node*, out: File*) {
 }
 
 function generate_assign_rax(expr: Node*, out: File*) {
+	//TODO: F64
 	generate_lvalue_rax(expr.assignment.lhs, out);
 	out.putsln("    push rax");
 	if(expr.assignment.op.type != TokenType::EQ) {
@@ -518,6 +523,14 @@ function generate_expr_rax(expr: Node*, out: File*) {
 		}
 		NodeType::POST_DECREMENT -> {
 			generate_post_decrement(expr, out);
+		}
+		NodeType::INT_TO_FLOAT -> {
+			generate_expr_rax(expr.unary, out);
+			out.putsln("    cvtsi2sd xmm0, rax");
+		}
+		NodeType::FLOAT_TO_INT -> {
+			generate_expr_rax(expr.unary, out);
+			out.putsln("    cvtsd2si rax, xmm0");
 		}
 		else -> {
 			eputs("Unsupported type in generate_expr_rax - "); eputs(node_type_to_string(expr.type)); eputln();
@@ -681,6 +694,9 @@ function generate_define_var(stmt: Node*, out: File*) {
 		if(stmt.variable.type.is_structural()) {
 			out.puts("lea rcx, [rbp-"); out.putd(stmt.variable.stackOffset); out.putsln("]");
 			generate_copy(stmt.variable.type.fields, 0, out);
+		}
+		else if(stmt.variable.type.is_float()) {
+			out.puts("    movsd [rbp-"); out.putd(stmt.variable.stackOffset); out.putsln("], xmm0");
 		}
 		else {
 			out.puts("    mov "); out.puts(stmt.variable.type.qualifier()); out.puts(" [rbp-"); out.putd(stmt.variable.stackOffset);

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -88,6 +88,21 @@ function cmp_suffix(type: int): i8* {
 	return null;
 }
 
+function ucmp_suffix(type: int): i8* {
+	when(type) {
+		NodeType::EQUAL -> return "e";
+		NodeType::NOT_EQUAL -> return "ne";
+		NodeType::LESS -> return "b";
+		NodeType::LESS_EQ -> return "na";
+		NodeType::GREATER -> return "a";
+		NodeType::GREATER_EQ -> return "nb";
+	}
+
+	eputs("Unsupported type in ucmp_suffix - "); eputs(node_type_to_string(type)); eputln();
+	exit(1);
+	return null;
+}
+
 function generate_addrof_rax(expr: Node*, out: File*) {
 	when(expr.unary.lvalue) {
 		LValue::LOCAL -> {
@@ -223,6 +238,17 @@ function generate_binary_float_arith(expr: Node*, out: File*) {
 	out.putsln("    movsd xmm0, xmm1");
 }
 
+function generate_float_comparison(expr: Node*, out: File*) {
+	generate_expr_rax(expr.binary.lhs, out);
+	out.putsln("    sub rsp, 8");
+	out.putsln("    movsd [rsp], xmm0");
+	generate_expr_rax(expr.binary.rhs, out);
+	out.putsln("    movsd xmm1, xmm0");
+	out.putsln("    movsd xmm0, [rsp]");
+	out.putsln("    add rsp, 8");
+	out.putsln("    ucomisd xmm0, xmm1");
+}
+
 function generate_binary_rax(expr: Node*, out: File*) {
 	if(expr.type == NodeType::OR) {
 		generate_logical_or_rax(expr, out);
@@ -237,6 +263,15 @@ function generate_binary_rax(expr: Node*, out: File*) {
 		assert(is_float_arithmetic(expr.type), "Invalid floating point operation in generate_binary");
 
 		generate_binary_float_arith(expr, out);
+		return;
+	}
+
+	if(is_comparison(expr.type) && expr.binary.lhs.computedType.is_float()) {
+		assert(expr.binary.rhs.computedType.is_float(), "Both sides of float operation must be floats - generate_binary");
+
+		generate_float_comparison(expr, out);
+		out.puts("    set"); out.puts(ucmp_suffix(expr.type)); out.putsln(" al");
+		out.putsln("    movzx rax, al");
 		return;
 	}
 

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -818,8 +818,14 @@ function generate_define_var(stmt: Node*, out: File*) {
 			itemType.indirection = itemType.indirection - 1;
 			for(var i = 0; i < array.block.children.size; ++i) {
 				generate_expr_rax(array.block.children.at(i), out);
-				out.puts("    mov "); out.puts(itemType.qualifier()); out.puts(" [rbp-"); out.putd(stmt.variable.stackOffset - (i * itemType.size()));
-				out.puts("], "); out.putsln(itemType.rax_subregister());
+				
+				if(itemType.is_float()) {
+					out.puts("    movsd [rbp-"); out.putd(stmt.variable.stackOffset - (i * 8)); out.putsln("], xmm0");
+				}
+				else {
+					out.puts("    mov "); out.puts(itemType.qualifier()); out.puts(" [rbp-"); out.putd(stmt.variable.stackOffset - (i * itemType.size()));
+					out.puts("], "); out.putsln(itemType.rax_subregister());
+				}
 			}
 			return;
 		}
@@ -1002,9 +1008,16 @@ function Parser.generate_program(ast: Node*, out: File*) {
 
 				for(var i = 0; i < array.block.children.size; ++i) {
 					generate_expr_rax(array.block.children.at(i), out);
-					out.puts("    mov "); out.puts(type.qualifier()); out.puts(" [_G");
-					out.put_name(&variable.variable.name); out.puts("+"); out.putd(i * itemType.size());
-					out.puts("], "); out.putsln(type.rax_subregister());
+
+					if(itemType.is_float()) {
+						out.puts("    movsd [_G"); out.put_name(&variable.variable.name); out.puts("+"); out.putd(i * 8);
+						out.putsln("], xmm0");
+					}
+					else {
+						out.puts("    mov "); out.puts(type.qualifier()); out.puts(" [_G");
+						out.put_name(&variable.variable.name); out.puts("+"); out.putd(i * itemType.size());
+						out.puts("], "); out.putsln(type.rax_subregister());
+					}
 				}
 				continue;
 			}

--- a/src/lexer.zpr
+++ b/src/lexer.zpr
@@ -140,6 +140,12 @@ function Lexer.skip_whitespace() {
 
 function Lexer.number(): Token* {
 	while(is_digit(this.peek())) this.advance();
+
+	if(this.match('.')) {
+		while(is_digit(this.peek())) this.advance();
+		return this.make_token(TokenType::FLOAT_LITERAL);
+	}
+
 	return this.make_token(TokenType::INT_LITERAL);
 }
 

--- a/src/lexer.zpr
+++ b/src/lexer.zpr
@@ -100,6 +100,7 @@ function Lexer.identifier_type(): int {
 	if(this.match_keyword("i16")) return TokenType::I16;
 	if(this.match_keyword("i32")) return TokenType::I32;
 	if(this.match_keyword("i64")) return TokenType::I64;
+	if(this.match_keyword("f64")) return TokenType::F64;
 	if(this.match_keyword("for")) return TokenType::FOR;
 	if(this.match_keyword("function")) return TokenType::FUNCTION;
 	if(this.match_keyword("namespace")) return TokenType::NAMESPACE;

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -208,6 +208,7 @@ function Parser.parse_type(): Type* {
 	else if(this.previous.type == TokenType::I16) type.type = DataType::I16;
 	else if(this.previous.type == TokenType::I32) type.type = DataType::I32;
 	else if(this.previous.type == TokenType::I64) type.type = DataType::I64;
+	else if(this.previous.type == TokenType::F64) type.type = DataType::F64;
 	else if(this.previous.type == TokenType::ANY) type.type = DataType::ANY;
 	else if(this.previous.type == TokenType::IDENTIFIER) {
 		type.type = DataType::UNRESOLVED;

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -17,6 +17,7 @@ struct Parser {
 	globalVars: Vector*;
 
 	strings: Vector*;
+	floats: Vector*;
 
 	definedTypes: Vector*;
 
@@ -38,6 +39,7 @@ function new_parser(lexer: Lexer*): Parser* {
 	parser.functions = new_vector();
 	parser.globalVars = new_vector();
 	parser.strings = new_vector();
+	parser.floats = new_vector();
 	parser.definedTypes = new_vector();
 	parser.lexerStack = new_vector();
 	parser.openedFiles = new_vector();
@@ -349,6 +351,23 @@ function Parser.parse_value(): Node* {
 		literalNode.literal.type = I8_TYPE;
 		literalNode.literal.az.integer = literal.start[1];
 
+		return literalNode;
+	}
+	else if(this.match(TokenType::FLOAT_LITERAL)) {
+		var literal = this.previous;
+		if(this.error) return null;
+
+		var literalNode = new_node(NodeType::FLOAT_LITERAL, literal);
+		literalNode.literal.type = F64_TYPE;
+
+		var str = malloc(literal.length + 1);
+		memcpy(str, literal.start, literal.length);
+		str[literal.length] = 0;
+
+		literalNode.literal.az.float.str = str;
+		literalNode.literal.az.float.id = this.floats.size;
+
+		this.floats.push(literalNode);
 		return literalNode;
 	}
 	else if(this.match(TokenType::STRING)) {

--- a/src/token.zpr
+++ b/src/token.zpr
@@ -72,6 +72,7 @@ enum TokenType {
 	I16,
 	I32,
 	I64,
+	F64,
 	FOR,
 	FUNCTION,
 	NAMESPACE,
@@ -164,6 +165,7 @@ function token_type_to_string(type: TokenType): i8* {
 		TokenType::I16 -> return "i16";
 		TokenType::I32 -> return "i32";
 		TokenType::I64 -> return "i64";
+		TokenType::F64 -> return "f64";
 		TokenType::FOR -> return "for";
 		TokenType::FUNCTION -> return "function";
 		TokenType::NAMESPACE -> return "namespace";

--- a/src/token.zpr
+++ b/src/token.zpr
@@ -54,6 +54,7 @@ enum TokenType {
 
 	INT_LITERAL,
 	CHAR_LITERAL,
+	FLOAT_LITERAL,
 	STRING,
 	IDENTIFIER,
 
@@ -147,6 +148,7 @@ function token_type_to_string(type: TokenType): i8* {
 
 		TokenType::INT_LITERAL -> return "int-literal";
 		TokenType::CHAR_LITERAL -> return "char-literal";
+		TokenType::FLOAT_LITERAL -> return "float-literal";
 		TokenType::STRING -> return "string";
 		TokenType::IDENTIFIER -> return "identifier";
 

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -473,6 +473,11 @@ function Parser.type_check_binary(expr: Node*) {
 	else if(left.assignable(F64_TYPE) && right.assignable(F64_TYPE) && is_float_arithmetic(expr.type)) {
 		// Valid
 	}
+	else if(left.assignable(F64_TYPE) && right.assignable(F64_TYPE) && is_comparison(expr.type)) {
+		expr.computedType = INT_TYPE;
+		tc_typeStack.push(INT_TYPE);
+		return;
+	}
 	else {
 		expr.print_position();
 		eputs("Cannot perform operation '"); eputs(node_type_to_string(expr.type)); eputs("' on types "); eputs(type_to_string(left));

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -567,6 +567,7 @@ function Parser.type_check_call(expr: Node*) {
 		}
 	}
 
+	expr.computedType = funktion.funktion.returnType;
 	tc_typeStack.push(funktion.funktion.returnType);
 }
 
@@ -631,6 +632,7 @@ function Parser.type_check_method_call(expr: Node*) {
 		}
 	}
 
+	expr.computedType = funktion.funktion.returnType;
 	tc_typeStack.push(funktion.funktion.returnType);
 }
 
@@ -656,6 +658,7 @@ function Parser.type_check_ternary_expr(expr: Node*) {
 		exit(1);
 	}
 
+	expr.computedType = doTrue;
 	tc_typeStack.push(doTrue);
 }
 
@@ -783,12 +786,15 @@ function Parser.type_check_expr(expr: Node*) {
 		this.type_check_binary(expr);
 	}
 	else if(expr.type == NodeType::INT_LITERAL) {
+		expr.computedType = INT_TYPE;
 		tc_typeStack.push(INT_TYPE);
 	}
 	else if(expr.type == NodeType::CHAR_LITERAL) {
+		expr.computedType = I8_TYPE;
 		tc_typeStack.push(I8_TYPE);
 	}
 	else if(expr.type == NodeType::STRING) {
+		expr.computedType = STR_TYPE;
 		tc_typeStack.push(STR_TYPE);
 	}
 	else if(expr.type == NodeType::ACCESS_VAR || expr.type == NodeType::ACCESS_GLOBAL_VAR) {

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -440,6 +440,12 @@ function Parser.type_check_unary(expr: Node*) {
 
 	var type: Type* = tc_typeStack.top();
 
+	expr.computedType = type;
+
+	if(type.is_float() && expr.type == NodeType::NEG) {
+		return;
+	}
+
 	if(!type.assignable(INT_TYPE)) {
 		expr.print_position();
 		eputs("Cannot perform operation '"); eputs(node_type_to_string(expr.type)); eputs("' on type "); eputs(type_to_string(type)); eputln();
@@ -456,16 +462,25 @@ function Parser.type_check_binary(expr: Node*) {
 
 	if((expr.type == NodeType::EQUAL || expr.type == NodeType::NOT_EQUAL) && left.indirection > 0 && right.indirection > 0 && left.assignable(right)) {
 		tc_typeStack.push(INT_TYPE);
+		expr.computedType = INT_TYPE;
 		return;
 	}
 
-	if(!left.assignable(INT_TYPE) || !right.assignable(INT_TYPE)) {
+	//TODO: float + int and int + float should be valid
+	if(left.assignable(INT_TYPE) && right.assignable(INT_TYPE)) {
+		// Valid
+	}
+	else if(left.assignable(F64_TYPE) && right.assignable(F64_TYPE) && is_float_arithmetic(expr.type)) {
+		// Valid
+	}
+	else {
 		expr.print_position();
 		eputs("Cannot perform operation '"); eputs(node_type_to_string(expr.type)); eputs("' on types "); eputs(type_to_string(left));
 		eputs(" and "); eputs(type_to_string(right)); eputln();
 		exit(1);
 	}
 
+	expr.computedType = left;
 	tc_typeStack.push(left);
 }
 
@@ -484,6 +499,7 @@ function Parser.type_check_access_var(expr: Node*) {
 
 		var decay = copy_type(expr.variable.type);
 
+		expr.computedType = decay;
 		tc_typeStack.push(decay);
 	}
 	else if(variable.type == NodeType::DEFINE_GLOBAL_VAR) {
@@ -491,6 +507,7 @@ function Parser.type_check_access_var(expr: Node*) {
 		expr.type = NodeType::ACCESS_GLOBAL_VAR;
 		expr.lvalue = LValue::GLOBAL;
 
+		expr.computedType = expr.variable.type;
 		tc_typeStack.push(expr.variable.type);
 	}
 	else if(variable.type == NodeType::DEFINE_CONST) {
@@ -500,6 +517,7 @@ function Parser.type_check_access_var(expr: Node*) {
 		expr.literal.type = INT_TYPE;
 		expr.literal.az.integer = value;
 
+		expr.computedType = INT_TYPE;
 		tc_typeStack.push(INT_TYPE);
 	}
 	else {
@@ -692,7 +710,7 @@ function Parser.type_check_access_member(expr: Node*) {
 	}
 
 	expr.member.memberRef = field;
-
+	expr.computedType = field.variable.type;
 	tc_typeStack.push(field.variable.type);
 }
 

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -798,6 +798,10 @@ function Parser.type_check_expr(expr: Node*) {
 		expr.computedType = I8_TYPE;
 		tc_typeStack.push(I8_TYPE);
 	}
+	else if(expr.type == NodeType::FLOAT_LITERAL) {
+		expr.computedType = F64_TYPE;
+		tc_typeStack.push(F64_TYPE);
+	}
 	else if(expr.type == NodeType::STRING) {
 		expr.computedType = STR_TYPE;
 		tc_typeStack.push(STR_TYPE);

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -18,6 +18,10 @@ function Type.is_integral(): bool {
 	);
 }
 
+function Type.is_float(): bool {
+	return this.indirection == 0 && this.type == DataType::F64;
+}
+
 function Type.is_void(): bool {
 	return this.indirection == 0 && this.type == DataType::VOID;
 }
@@ -82,6 +86,7 @@ function Type.size(): int {
 	if(this.type == DataType::I16) return 2;
 	if(this.type == DataType::I32) return 4;
 	if(this.type == DataType::I64) return 8;
+	if(this.type == DataType::F64) return 8;
 	if(this.type == DataType::ANY) return 8;
 	if(this.type == DataType::STRUCT) {
 		var size = 0;
@@ -791,6 +796,22 @@ function Parser.type_check_expr(expr: Node*) {
 		//       or requires a warning in some cases is to be decided.
 		this.type_check_expr(expr.unary);
 		resolve_type(expr.computedType);
+
+		var unaryType: Type* = tc_typeStack.pop();
+
+		if(unaryType.is_integral() && expr.computedType.is_float()) {
+			expr.type = NodeType::INT_TO_FLOAT;
+		}
+		else if(unaryType.is_float() && expr.computedType.is_integral()) {
+			expr.type = NodeType::FLOAT_TO_INT;
+		}
+
+		tc_typeStack.push(expr.computedType);
+	}
+	else if(expr.type == NodeType::INT_TO_FLOAT) {
+		tc_typeStack.push(F64_TYPE);
+	}
+	else if(expr.type == NodeType::FLOAT_TO_INT) {
 		tc_typeStack.push(expr.computedType);
 	}
 	else if(expr.type == NodeType::ACCESS_MEMBER) {

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -466,7 +466,6 @@ function Parser.type_check_binary(expr: Node*) {
 		return;
 	}
 
-	//TODO: float + int and int + float should be valid
 	if(left.assignable(INT_TYPE) && right.assignable(INT_TYPE)) {
 		// Valid
 	}
@@ -477,6 +476,30 @@ function Parser.type_check_binary(expr: Node*) {
 		expr.computedType = INT_TYPE;
 		tc_typeStack.push(INT_TYPE);
 		return;
+	}
+	// With int <-> float, float always takes priority
+	else if((left.assignable(F64_TYPE) && right.assignable(INT_TYPE)) || (left.assignable(INT_TYPE) && right.assignable(F64_TYPE))) {
+		if(left.assignable(INT_TYPE)) {
+			var cast = new_node(NodeType::INT_TO_FLOAT, expr.binary.lhs.position);
+			cast.computedType = F64_TYPE;
+			cast.unary = expr.binary.lhs;
+			expr.binary.lhs = cast;
+			left = F64_TYPE;
+		}
+		// Right is an integer
+		else {
+			var cast = new_node(NodeType::INT_TO_FLOAT, expr.binary.rhs.position);
+			cast.computedType = F64_TYPE;
+			cast.unary = expr.binary.rhs;
+			expr.binary.rhs = cast;
+			right = F64_TYPE;
+		}
+
+		if(is_comparison(expr.type)) {
+			expr.computedType = INT_TYPE;
+			tc_typeStack.push(INT_TYPE);
+			return;
+		}
 	}
 	else {
 		expr.print_position();
@@ -747,7 +770,19 @@ function Parser.type_check_assign(expr: Node*) {
 	var rhs: Type* = tc_typeStack.pop();
 	resolve_type(rhs);
 
-	if(!rhs.assignable(lhs)) {
+	if(lhs.is_integral() && rhs.is_float()) {
+		var cast = new_node(NodeType::FLOAT_TO_INT, expr.assignment.lhs.position);
+		cast.computedType = INT_TYPE;
+		cast.unary = expr.assignment.rhs;
+		expr.assignment.rhs = cast;
+	}
+	else if(lhs.is_float() && rhs.is_integral()) {
+		var cast = new_node(NodeType::INT_TO_FLOAT, expr.assignment.lhs.position);
+		cast.computedType = INT_TYPE;
+		cast.unary = expr.assignment.rhs;
+		expr.assignment.rhs = cast;
+	}
+	else if(!rhs.assignable(lhs)) {
 		expr.print_position();
 		eputs("Cannot assign type "); eputs(type_to_string(rhs)); eputs(" to type "); eputs(type_to_string(lhs));
 		eputln();
@@ -933,7 +968,19 @@ function Parser.type_check_define_var(stmt: Node*) {
 		var valueType: Type* = tc_typeStack.pop();
 		resolve_type(valueType);
 
-		if(!valueType.assignable(declType)) {
+		if(declType.is_integral() && valueType.is_float()) {
+			var cast = new_node(NodeType::FLOAT_TO_INT, stmt.position);
+			cast.computedType = INT_TYPE;
+			cast.unary = stmt.variable.value;
+			stmt.variable.value = cast;
+		}
+		else if(declType.is_float() && valueType.is_integral()) {
+			var cast = new_node(NodeType::INT_TO_FLOAT, stmt.position);
+			cast.computedType = INT_TYPE;
+			cast.unary = stmt.variable.value;
+			stmt.variable.value = cast;
+		}
+		else if(!valueType.assignable(declType)) {
 			stmt.print_position();
 			eputs("Cannot assign type "); eputs(type_to_string(valueType)); eputs(" to variable expecting "); eputs(type_to_string(declType));
 			eputln();
@@ -1218,7 +1265,19 @@ function Parser.type_check_global_var(stmt: Node*) {
 		var valueType: Type* = tc_typeStack.pop();
 		resolve_type(valueType);
 
-		if(!valueType.assignable(declType)) {
+		if(declType.is_integral() && valueType.is_float()) {
+			var cast = new_node(NodeType::FLOAT_TO_INT, stmt.position);
+			cast.computedType = INT_TYPE;
+			cast.unary = stmt.variable.value;
+			stmt.variable.value = cast;
+		}
+		else if(declType.is_float() && valueType.is_integral()) {
+			var cast = new_node(NodeType::INT_TO_FLOAT, stmt.position);
+			cast.computedType = INT_TYPE;
+			cast.unary = stmt.variable.value;
+			stmt.variable.value = cast;
+		}
+		else if(!valueType.assignable(declType)) {
 			stmt.print_position();
 			eputs("Cannot assign type "); eputs(type_to_string(valueType)); eputs(" to variable expecting "); eputs(type_to_string(declType));
 			eputln();

--- a/src/types.zpr
+++ b/src/types.zpr
@@ -3,6 +3,7 @@ import "src/ast.zpr";
 var INT_TYPE: Type*;
 var I8_TYPE: Type*;
 var STR_TYPE: Type*;
+var F64_TYPE: Type*;
 var VOID_TYPE: Type*;
 var ANY_TYPE: Type*;
 
@@ -32,6 +33,9 @@ function build_types() {
 	STR_TYPE = new_type();
 	STR_TYPE.type = DataType::I8;
 	STR_TYPE.indirection = 1;
+
+	F64_TYPE = new_type();
+	F64_TYPE.type = DataType::F64;
 
 	VOID_TYPE = new_type();
 	VOID_TYPE.type = DataType::VOID;

--- a/std/io.zpr
+++ b/std/io.zpr
@@ -5,6 +5,17 @@ const stdin = 0;
 const stdout = 1;
 const stderr = 2;
 
+const __FLOAT_PUT_PRECISION = 7;
+const __FLOAT_PUT_BUF_LENGTH = 8; //TODO: Inline as __FLOAT_PUT_PRECISION + 1
+
+//TODO: Make a built-in
+function assert(condition: bool, message: i8*) {
+	if(!condition) {
+		eputsln(message);
+		exit(1);
+	}
+}
+
 // ========== fput family ==========
 
 function fputln(fd: int) {
@@ -40,6 +51,43 @@ function fputd(fd: int, val: int) {
 	fputs(fd, buffer);
 }
 
+function fputft(fd: int, val: f64) {
+	var ipart: i64 = val;
+	var frac = val - ipart;
+	
+	if(ipart < 0) {
+		fputc(fd, '-');
+		ipart = -ipart;
+		frac = -frac;
+	}
+
+	fputu(fd, ipart);
+	fputc(fd, '.');
+
+	var buf: i8[__FLOAT_PUT_BUF_LENGTH];
+
+	if(frac == 0) {
+		buf[0] = '0';
+		buf[1] = 0;
+	}
+	else {
+		for(var i = 0; i < __FLOAT_PUT_PRECISION; ++i) {
+			var dig: i8 = (frac * 10.0);
+			buf[i] = '0' + dig;
+			frac = frac * 10.0 - dig;
+		}
+
+		for(var i = __FLOAT_PUT_PRECISION - 1; i >= 0; --i) {
+			var n = buf[i] - '0';
+			if(n != 0) {
+				buf[i + 1] = 0;
+				break;
+			}
+		}
+	}
+	fputs(fd, buf);
+}
+
 // ========== put family ==========
 
 function putln() {
@@ -66,6 +114,10 @@ function putd(val: int) {
 	fputd(stdout, val);
 }
 
+function putft(val: f64) {
+	fputft(stdout, val);
+}
+
 // ========== eput family ==========
 
 function eputln() {
@@ -90,6 +142,10 @@ function eputu(val: int) {
 
 function eputd(val: int) {
 	fputd(stderr, val);
+}
+
+function eputft(val: f64) {
+	fputft(stderr, val);
 }
 
 // ========== Files ==========
@@ -171,6 +227,43 @@ function File.putd(val: int) {
 	itoa(val, buffer, 10);
 
 	this.write(buffer, strlen(buffer));
+}
+
+function File.putft(val: f64) {
+	var ipart: i64 = val;
+	var frac = val - ipart;
+	
+	if(ipart < 0) {
+		this.putc('-');
+		ipart = -ipart;
+		frac = -frac;
+	}
+
+	this.putu(ipart);
+	this.putc('.');
+
+	var buf: i8[__FLOAT_PUT_BUF_LENGTH];
+
+	if(frac == 0) {
+		buf[0] = '0';
+		buf[1] = 0;
+	}
+	else {
+		for(var i = 0; i < __FLOAT_PUT_PRECISION; ++i) {
+			var dig: i8 = (frac * 10.0);
+			buf[i] = '0' + dig;
+			frac = frac * 10.0 - dig;
+		}
+
+		for(var i = __FLOAT_PUT_PRECISION - 1; i >= 0; --i) {
+			var n = buf[i] - '0';
+			if(n != 0) {
+				buf[i + 1] = 0;
+				break;
+			}
+		}
+	}
+	this.puts(buf);
 }
 
 // ===== Reading =====

--- a/tests/core.sh
+++ b/tests/core.sh
@@ -1016,10 +1016,10 @@ enum Animal {
 }
 
 function main(): int {
-	printu(DOG);
-	printu(CAT);
-	printu(ZEBRA);
-	printu(BEAR);
+	printu(Animal::DOG);
+	printu(Animal::CAT);
+	printu(Animal::ZEBRA);
+	printu(Animal::BEAR);
 	return 0;
 }
 "
@@ -1162,6 +1162,8 @@ function main(): int {
 "
 
 assert_stdout "Hello, World!" "
+import \"std/io.zpr\";
+
 namespace hello {
 	var message = \"Hello, World!\";
 	namespace world {
@@ -1170,6 +1172,8 @@ namespace hello {
 		}
 	}
 }
+
+function main(): int {  hello::world::print(); return 0; }
 "
 
 assert_stdout "10" "
@@ -1273,6 +1277,322 @@ function main(): int {
 		Type::A -> putsln(\"A\");
 		Type::B -> putsln(\"B\");
 	}
+
+	return 0;
+}
+"
+
+echo " Done"
+
+echo -n "Floats: "
+
+assert_stdout "10" "
+function main(): int {
+	var x = 10 as f64;
+	var y = x as int;
+
+	printu(y);
+
+	return 0;
+}
+"
+
+assert_stdout "20" "
+function main(): int {
+	var x = 10 as f64;
+	x += x;
+
+	printu(x as int);
+
+	return 0;
+}
+"
+
+assert_stdout "25" "
+function sum(a: f64, b: f64): f64 {
+	return a + b;
+}
+
+function main(): int {
+	var x = sum(10 as f64, 15 as f64);
+
+	printu(x as int);
+
+	return 0;
+}
+"
+
+assert_stdout "10" "
+var x: f64;
+
+function main(): int {
+	x = 10 as f64;
+
+	printu(x as int);
+
+	return 0;
+}
+"
+
+assert_stdout "2.5" "
+import \"std/io.zpr\";
+
+function main(): int {
+	var x = 5 as f64;
+	x /= 2 as f64;
+
+	putft(x);
+
+	return 0;
+}
+"
+
+assert_stdout "10.0, 15.0" "
+import \"std/io.zpr\";
+struct Point {
+	x: f64;
+	y: f64;
+}
+
+function Point.println() {
+	putft(this.x);
+	puts(\", \");
+	putft(this.y);
+	putln();
+}
+
+function main(): int {
+	var point: Point;
+	point.x = 10 as f64;
+	point.y = 15 as f64;
+
+	point.println();
+
+	return 0;
+}
+"
+
+assert_stdout "(20.0, 25.0)" "
+import \"std/io.zpr\";
+
+struct Point {
+	x: f64;
+	y: f64;
+}
+
+function Point.translate(dx: f64, dy: f64) {
+	this.x += dx;
+	this.y += dy;
+}
+
+function Point.println() {
+	puts(\"(\");
+	putft(this.x);
+	puts(\", \");
+	putft(this.y);
+	putsln(\")\");
+}
+
+function main(): int {
+	var point: Point;
+	point.x = 15 as f64;
+	point.y = 10 as f64;
+
+	point.translate(5 as f64, 15 as f64);
+
+	point.println();
+
+	return 0;
+}
+"
+
+assert_stdout "0.0
+1.0
+2.0
+3.0
+4.0" "
+import \"std/io.zpr\";
+
+function main(): int {
+	var arr: f64[5];
+
+	for(var i = 0; i < 5; ++i) {
+		arr[i] = i as f64;
+	}
+
+	for(var i = 0; i < 5; ++i) {
+		putft(arr[i]);
+		putln();
+	}
+
+	return 0;
+}
+"
+
+assert_stdout "0.0
+1.0
+2.0
+3.0
+4.0" "
+import \"std/io.zpr\";
+
+function main(): int {
+	var arr: f64[5] = [ 0 as f64, 1 as f64, 2 as f64, 3 as f64, 4 as f64 ];
+
+	for(var i = 0; i < 5; ++i) {
+		putft(arr[i]);
+		putln();
+	}
+
+	return 0;
+}
+"
+
+assert_stdout "0.0
+1.0
+2.0
+3.0
+4.0" "
+import \"std/io.zpr\";
+
+var arr: f64[5] = [ 0 as f64, 1 as f64, 2 as f64, 3 as f64, 4 as f64 ];
+
+function main(): int {
+
+	for(var i = 0; i < 5; ++i) {
+		putft(arr[i]);
+		putln();
+	}
+
+	return 0;
+}
+"
+
+assert_stdout "1
+0
+1
+0
+0
+1" "
+function main(): int {
+
+	var fiveHalves = 5 as f64;
+	fiveHalves /= 2 as f64;
+
+	var two = 2 as f64;
+
+	printu(fiveHalves > two);
+	printu(fiveHalves < two);
+	printu(fiveHalves >= two);
+	printu(fiveHalves <= two);
+	printu(fiveHalves == two);
+	printu(fiveHalves != two);
+
+	return 0;
+}
+"
+
+assert_stdout "2.5" "
+import \"std/io.zpr\";
+
+function main(): int {
+	var x = 2.5;
+
+	putft(x);
+	putln();
+
+	return 0;
+}
+"
+
+assert_stdout "12.5" "
+import \"std/io.zpr\";
+
+function main(): int {
+	var x = 2.5;
+
+	x += 10;
+
+	putft(x); putln();
+
+	return 0;
+}
+"
+
+assert_stdout "10.0" "
+import \"std/io.zpr\";
+
+function main(): int {
+	var x = 2.5;
+
+	x = 10;
+
+	putft(x); putln();
+
+	return 0;
+}
+"
+
+assert_stdout "2" "
+import \"std/io.zpr\";
+
+function main(): int {
+	var x = 2.5;
+	var y: i64;
+	y = x;
+
+	putd(y); putln();
+
+	return 0;
+}
+"
+
+assert_stdout "10.0" "
+import \"std/io.zpr\";
+
+
+function main(): int {
+	var x: f64 = 10;
+
+	putft(x); putln();
+
+	return 0;
+}
+"
+
+assert_stdout "10.0" "
+import \"std/io.zpr\";
+
+var x: f64 = 10;
+
+function main(): int {
+
+	putft(x); putln();
+
+	return 0;
+}
+"
+
+assert_stdout "10" "
+import \"std/io.zpr\";
+
+function main(): int {
+	var x: int = 10.5;
+
+	putd(x); putln();
+
+	return 0;
+}
+"
+
+assert_stdout "10" "
+import \"std/io.zpr\";
+
+var x: int = 10.5;
+
+function main(): int {
+
+	putd(x); putln();
 
 	return 0;
 }


### PR DESCRIPTION
This pr adds support for floats (type: `f64`), which implement IEEE 754 double-precision floating point numbers. They support the arithmetic and comparison operators, literals, and implicit casting from ints to floats and from floats to ints.

E.g.:
```
import "std/io.zpr";
function main(): int {
  var x = 5.0;
  x /= 2;
  putft(x); // 2.5
  
  return 0;
}
```