### PR TITLE
Dead Code Elimination

### DIFF
--- a/bootstrap/bootstrap_x86_64_linux.yasm
+++ b/bootstrap/bootstrap_x86_64_linux.yasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d3ad9fcafb184fd5422a6e2775c6ce7409e675bedd1ea0bd92d2d7205c08c428
-size 629276
+oid sha256:7352246cbb796c11c52948d9887d4deca037ef4f5d702044fd9783d93861550f
+size 643846

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -190,6 +190,8 @@ struct Node {
 		};
 
 		variable: struct {
+			used: bool;
+			
 			name: Name;
 			type: Type*;
 			value: Node*;

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -173,6 +173,7 @@ struct Node {
 
 		literal: struct {
 			type: Type*;
+			used: bool;
 
 			az: union {
 				integer: int;

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -147,9 +147,9 @@ struct Node {
 			name: Name;
 			returnType: Type*;
 			body: Node*;
-			hasImplicitBody: int;
+			hasImplicitBody: bool;
 
-			isMethod: int;
+			isMethod: bool;
 			parent: Node*;
 			parentType: Type*;
 
@@ -157,7 +157,8 @@ struct Node {
 
 			localVariableStackOffset: int;
 
-			used: int;
+			used: bool;
+			dced: bool;
 		};
 
 		block: struct {

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -473,6 +473,8 @@ function node_type_to_string(type: NodeType): i8* {
 		NodeType::DEREF -> return "*";
 		NodeType::SIZEOF -> return "sizeof";
 		NodeType::ACCESS_SUBSCRIPT -> return "[";
+		NodeType::ACCESS_MEMBER -> return ".";
+		NodeType::ASSIGN -> return "=";
 		NodeType::PRE_INCREMENT -> return "++";
 		NodeType::PRE_DECREMENT -> return "--";
 		NodeType::POST_INCREMENT -> return "++";

--- a/src/builtin.zpr
+++ b/src/builtin.zpr
@@ -1,6 +1,8 @@
 import "std/core.zpr";
 import "src/ast.zpr";
 
+var builtinFunctions: Vector*;
+
 function add_implicit_printu_function(): Node* {
 	var name = synthetic_token(TokenType::IDENTIFIER, "printu");
 	var funktion = new_node(NodeType::FUNCTION, name);
@@ -61,6 +63,8 @@ function parser_builtin_functions(): Vector* {
 	functions.push(add_implicit_syscall_function("syscall4", 4));
 	functions.push(add_implicit_syscall_function("syscall5", 5));
 
+	builtinFunctions = functions;
+
 	return functions;
 }
 
@@ -100,12 +104,15 @@ function generate_implicit_printu_impl(out: File*) {
 }
 
 function generate_builtin_functions(out: File*) {
-	generate_implicit_printu_impl(out);
+	if((builtinFunctions.at(0) as Node*).funktion.used)
+		generate_implicit_printu_impl(out);
 
 	var ARG_REGISTERS: i8*[6] = [ "rdi", "rsi", "rdx", "rcx", "r8", "r9" ];
 	var SYS_REGISTERS: i8*[6] = [ "rax", "rdi", "rsi", "rdx", "r10", "r8" ];
 
 	for(var i = 0; i <= 5; ++i) {
+		if(!(builtinFunctions.at(i + 1) as Node*).funktion.used) continue;
+
 		out.puts("_FZsyscall"); out.putd(i); out.putsln(":");
 
 		for(var arg = 0; arg <= i; arg = arg + 1) {

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -1065,6 +1065,9 @@ function Parser.generate_program(ast: Node*, out: File*) {
 
 	for(var i = 0; i < this.globalVars.size; ++i) {
 		var variable: Node* = this.globalVars.at(i);
+
+		if(!variable.variable.used) continue;
+
 		var type = variable.variable.type;
 
 		if(variable.variable.value != null) {
@@ -1115,6 +1118,8 @@ function Parser.generate_program(ast: Node*, out: File*) {
 
 		for(var i = 0; i < this.globalVars.size; ++i) {
 			var variable: Node* = this.globalVars.at(i);
+
+			if(!variable.variable.used) continue;
 
 			out.puts("_G"); out.put_name(&variable.variable.name); out.puts(": ");
 			

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -1131,11 +1131,13 @@ function Parser.generate_program(ast: Node*, out: File*) {
 		}
 	}
 
-	if(this.strings.size > 0) {
+	if(this.strings.size > 0 || this.floats.size > 0) {
 		out.putsln("section .data");
 
 		for(var i = 0; i < this.strings.size; ++i) {
 			var str: Node* = this.strings.at(i);
+
+			if(!str.literal.used) continue;
 
 			out.puts("_S"); out.putd(str.literal.az.string.id); out.puts(": db "); out.putc('"'); out.puts(str.literal.az.string.chars);
 			out.putc('"'); out.putsln(", 0");
@@ -1143,6 +1145,8 @@ function Parser.generate_program(ast: Node*, out: File*) {
 
 		for(var i = 0; i < this.floats.size; ++i) {
 			var float: Node* = this.floats.at(i);
+
+			if(!float.literal.used) continue;
 
 			out.puts("_D"); out.putd(float.literal.az.float.id); out.puts(": dq "); out.putsln(float.literal.az.float.str);
 		}

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -1026,7 +1026,7 @@ function Parser.generate_namespace(node: Node*, out: File*) {
 function Parser.generate_top_level_declaration(node: Node*, out: File*) {
 	when(node.type) {
 		NodeType::FUNCTION -> {
-			if(node.funktion.used)
+			if(node.funktion.used || !m_dce)
 				generate_function(node, out);
 		}
 		NodeType::DEFINE_GLOBAL_VAR -> {

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -1026,7 +1026,7 @@ function Parser.generate_namespace(node: Node*, out: File*) {
 function Parser.generate_top_level_declaration(node: Node*, out: File*) {
 	when(node.type) {
 		NodeType::FUNCTION -> {
-			if(node.funktion.used || !m_dce)
+			if(node.funktion.used)
 				generate_function(node, out);
 		}
 		NodeType::DEFINE_GLOBAL_VAR -> {

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -69,8 +69,13 @@ function Parser.dce_expression(expr: Node*) {
 		NodeType::FLOAT_LITERAL, NodeType::STRING -> {
 			expr.literal.used = true;
 		}
+		NodeType::ACCESS_GLOBAL_VAR -> {
+			var variable = this.lookup_variable(&expr.variable.name);
+			assert(variable.type == NodeType::DEFINE_GLOBAL_VAR, "typechecker must verify global variable type");
+			variable.variable.used = true;
+		}
 		NodeType::SIZEOF,
-		NodeType::CHAR_LITERAL, NodeType::INT_LITERAL, NodeType::ACCESS_VAR, NodeType::ACCESS_GLOBAL_VAR -> {}
+		NodeType::CHAR_LITERAL, NodeType::INT_LITERAL, NodeType::ACCESS_VAR -> {}
 		else -> {
 			eputs("dce_expression unsupported node - ");
 			eputsln(node_type_to_string(expr.type));

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -66,8 +66,11 @@ function Parser.dce_expression(expr: Node*) {
 				this.dce_expression(expr.block.children.at(i));
 			}
 		}
+		NodeType::FLOAT_LITERAL, NodeType::STRING -> {
+			expr.literal.used = true;
+		}
 		NodeType::SIZEOF,
-		NodeType::CHAR_LITERAL, NodeType::INT_LITERAL, NodeType::FLOAT_LITERAL, NodeType::STRING, NodeType::ACCESS_VAR, NodeType::ACCESS_GLOBAL_VAR -> {}
+		NodeType::CHAR_LITERAL, NodeType::INT_LITERAL, NodeType::ACCESS_VAR, NodeType::ACCESS_GLOBAL_VAR -> {}
 		else -> {
 			eputs("dce_expression unsupported node - ");
 			eputsln(node_type_to_string(expr.type));
@@ -161,4 +164,11 @@ function Parser.dce() {
 	}
 
 	this.dce_function(main);
+
+	for(var i = 0; i < this.globalVars.size; ++i) {
+		var gvar: Node* = this.globalVars.at(i);
+
+		if(gvar.variable.value != null)
+			this.dce_expression(gvar.variable.value);
+	}
 }

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -4,27 +4,119 @@ import "src/ast.zpr";
 import "src/typecheck.zpr";
 
 function Parser.dce_expression(expr: Node*) {
+	if(is_binary_op(expr.type)) {
+		this.dce_expression(expr.binary.lhs);
+		this.dce_expression(expr.binary.rhs);
+		return;
+	}
+	else if(is_unary_op(expr.type)) {
+		this.dce_expression(expr.unary);
+		return;
+	}
+
 	when(expr.type) {
 		NodeType::CALL -> {
 			var funktion = this.lookup_variable(&expr.funktion.name);
 			assert(funktion.type == NodeType::FUNCTION, "Typecheck must verify function call type");
+
+			for(var i = 0; i < expr.funktion.arguments.size; ++i) {
+				this.dce_expression(expr.funktion.arguments.at(i));
+			}
 
 			if(!funktion.funktion.dced) {
 				funktion.funktion.dced = true;
 				this.dce_function(funktion);
 			}
 		}
-		NodeType::INT_LITERAL -> {}
+		NodeType::CALL_METHOD -> {
+			this.dce_expression(expr.funktion.parent);
+			var funktion = expr.funktion.parentType.lookup_method(&expr.funktion.name);
+
+			for(var i = 0; i < expr.funktion.arguments.size; ++i) {
+				this.dce_expression(expr.funktion.arguments.at(i));
+			}
+
+			if(!funktion.funktion.dced) {
+				funktion.funktion.dced = true;
+				this.dce_function(funktion);
+			}
+		}
+		NodeType::TERNARY -> {
+			this.dce_expression(expr.conditional.condition);
+			this.dce_expression(expr.conditional.doTrue);
+			this.dce_expression(expr.conditional.doFalse);
+		}
+		NodeType::CAST, NodeType::INT_TO_FLOAT, NodeType::FLOAT_TO_INT,
+		NodeType::PRE_INCREMENT, NodeType::PRE_DECREMENT, NodeType::POST_INCREMENT, NodeType::POST_DECREMENT -> {
+			this.dce_expression(expr.unary);
+		}
+		NodeType::ACCESS_SUBSCRIPT -> {
+			this.dce_expression(expr.binary.lhs);
+			this.dce_expression(expr.binary.rhs);
+		}
+		NodeType::ASSIGN -> {
+			this.dce_expression(expr.assignment.lhs);
+			this.dce_expression(expr.assignment.rhs);
+		}
+		NodeType::ACCESS_MEMBER -> {
+			this.dce_expression(expr.member.parent);
+		}
+		NodeType::ARRAY_INIT -> {
+			for(var i = 0; i < expr.block.children.size; ++i) {
+				this.dce_expression(expr.block.children.at(i));
+			}
+		}
+		NodeType::SIZEOF,
+		NodeType::CHAR_LITERAL, NodeType::INT_LITERAL, NodeType::FLOAT_LITERAL, NodeType::STRING, NodeType::ACCESS_VAR, NodeType::ACCESS_GLOBAL_VAR -> {}
 		else -> {
 			eputs("dce_expression unsupported node - ");
 			eputsln(node_type_to_string(expr.type));
+			eputd(expr.type); eputln();
 			exit(1);
 		}
 	}
 }
 
+function Parser.dce_block(block: Node*) {
+	for(var i = 0; i < block.block.children.size; ++i) {
+		this.dce_statement(block.block.children.at(i));
+	}
+}
+
 function Parser.dce_statement(stmt: Node*) {
 	when(stmt.type) {
+		NodeType::IF -> {
+			this.dce_expression(stmt.conditional.condition);
+			this.dce_statement(stmt.conditional.doTrue);
+			if(stmt.conditional.doFalse != null) this.dce_statement(stmt.conditional.doFalse);
+		}
+		NodeType::FOR -> {
+			if(stmt.loop.initial != null)
+				this.dce_statement(stmt.loop.initial);
+			if(stmt.loop.condition != null)
+				this.dce_expression(stmt.loop.condition);
+			if(stmt.loop.iteration != null)
+				this.dce_expression(stmt.loop.iteration);
+			this.dce_statement(stmt.loop.body);
+		}
+		NodeType::WHILE, NodeType::DO_WHILE -> {
+			this.dce_expression(stmt.conditional.condition);
+			this.dce_statement(stmt.conditional.doTrue);
+		}
+		NodeType::WHEN -> {
+			this.dce_expression(stmt.vhen.match);
+			for(var i = 0; i < stmt.vhen.branches.size; ++i)
+				this.dce_statement((stmt.vhen.branches.at(i) as Node*).branch.body);
+			if(stmt.vhen.default != null)
+				this.dce_statement(stmt.vhen.default);
+		}
+		NodeType::DEFINE_VAR -> {
+			if(stmt.variable.value != null)
+				this.dce_expression(stmt.variable.value);
+		}
+		NodeType::BLOCK -> {
+			this.dce_block(stmt);
+		}
 		NodeType::EXPR_STMT -> {
 			this.dce_expression(stmt.unary);
 		}
@@ -32,6 +124,7 @@ function Parser.dce_statement(stmt: Node*) {
 			if(stmt.unary != null)
 				this.dce_expression(stmt.unary);
 		}
+		NodeType::BREAK, NodeType::CONTINUE -> {}
 		else -> {
 			eputs("dce_statement unsupported node - ");
 			eputsln(node_type_to_string(stmt.type));
@@ -42,9 +135,10 @@ function Parser.dce_statement(stmt: Node*) {
 
 function Parser.dce_function(funktion: Node*) {
 	funktion.funktion.used = true;
-	for(var i = 0; i < funktion.funktion.body.block.children.size; ++i) {
-		this.dce_statement(funktion.funktion.body.block.children.at(i));
-	}
+	if(!funktion.funktion.hasImplicitBody)
+		for(var i = 0; i < funktion.funktion.body.block.children.size; ++i) {
+			this.dce_statement(funktion.funktion.body.block.children.at(i));
+		}
 }
 
 function Parser.dce() {

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -1,0 +1,70 @@
+import "std/core.zpr";
+import "std/io.zpr";
+import "src/ast.zpr";
+import "src/typecheck.zpr";
+
+function Parser.dce_expression(expr: Node*) {
+	when(expr.type) {
+		NodeType::CALL -> {
+			var funktion = this.lookup_variable(&expr.funktion.name);
+			assert(funktion.type == NodeType::FUNCTION, "Typecheck must verify function call type");
+
+			if(!funktion.funktion.dced) {
+				funktion.funktion.dced = true;
+				this.dce_function(funktion);
+			}
+		}
+		NodeType::INT_LITERAL -> {}
+		else -> {
+			eputs("dce_expression unsupported node - ");
+			eputsln(node_type_to_string(expr.type));
+			exit(1);
+		}
+	}
+}
+
+function Parser.dce_statement(stmt: Node*) {
+	when(stmt.type) {
+		NodeType::EXPR_STMT -> {
+			this.dce_expression(stmt.unary);
+		}
+		NodeType::RETURN -> {
+			if(stmt.unary != null)
+				this.dce_expression(stmt.unary);
+		}
+		else -> {
+			eputs("dce_statement unsupported node - ");
+			eputsln(node_type_to_string(stmt.type));
+			exit(1);
+		}
+	}
+}
+
+function Parser.dce_function(funktion: Node*) {
+	funktion.funktion.used = true;
+	for(var i = 0; i < funktion.funktion.body.block.children.size; ++i) {
+		this.dce_statement(funktion.funktion.body.block.children.at(i));
+	}
+}
+
+function Parser.dce() {
+	var mainTok = synthetic_token(TokenType::IDENTIFIER, "main");
+	var mainName: Name;
+	this.bind_name(&mainName, mainTok);
+
+	var main = this.lookup_variable(&mainName);
+	main.funktion.dced = true;
+
+	if(main == null) {
+		eputsln("A 'main' function must be defined for a zephyr program");
+		exit(1);
+	}
+
+	if(main.type != NodeType::FUNCTION) {
+		main.print_position();
+		eputsln("'main' must be a function");
+		exit(1);
+	}
+
+	this.dce_function(main);
+}

--- a/src/main.zpr
+++ b/src/main.zpr
@@ -4,15 +4,17 @@ import "std/subprocess.zpr";
 import "src/lexer.zpr";
 import "src/types.zpr";
 import "src/parser.zpr";
+var m_dce: bool; // codegen needs m_dce
 import "src/codegen.zpr";
 import "src/typecheck.zpr";
+import "src/dce.zpr";
 
 // Prefixed with m_ for main
 
 var m_filepath: i8*;
 var m_cliSource: i8*;
 var m_outFile: i8*;
-var m_dumpAst: int;
+var m_dumpAst: bool;
 
 function usage_exit(out: int, code: int) {
 	fputsln(out, "Possible Arguments:");
@@ -43,6 +45,9 @@ function parse_cli_args(argc: int, argv: i8**): i8** {
 			if(argc - i == 0) usage_exit(stderr, 1);
 			m_outFile = argv[i + 1];
 			++i;
+		}
+		else if(streq(argv[i], "--dce")) {
+			m_dce = true;
 		}
 		else if(streq(argv[i], "--")) {
 			break;
@@ -104,6 +109,9 @@ function main(argc: int, argv: i8**): int {
 		print_ast(ast);
 
 	parser.type_check(ast);
+
+	if(m_dce)
+		parser.dce();
 
 	var asmFile: i8[1024];
 

--- a/src/main.zpr
+++ b/src/main.zpr
@@ -4,7 +4,6 @@ import "std/subprocess.zpr";
 import "src/lexer.zpr";
 import "src/types.zpr";
 import "src/parser.zpr";
-var m_dce: bool; // codegen needs m_dce
 import "src/codegen.zpr";
 import "src/typecheck.zpr";
 import "src/dce.zpr";
@@ -45,9 +44,6 @@ function parse_cli_args(argc: int, argv: i8**): i8** {
 			if(argc - i == 0) usage_exit(stderr, 1);
 			m_outFile = argv[i + 1];
 			++i;
-		}
-		else if(streq(argv[i], "--dce")) {
-			m_dce = true;
 		}
 		else if(streq(argv[i], "--")) {
 			break;
@@ -110,8 +106,7 @@ function main(argc: int, argv: i8**): int {
 
 	parser.type_check(ast);
 
-	if(m_dce)
-		parser.dce();
+	parser.dce();
 
 	var asmFile: i8[1024];
 

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -572,8 +572,6 @@ function Parser.type_check_call(expr: Node*) {
 		exit(1);
 	}
 
-	funktion.funktion.used = true;
-
 	if(funktion.funktion.arguments.size != expr.funktion.arguments.size) {
 		expr.print_position();
 		eputs("Call expected "); eputd(funktion.funktion.arguments.size); eputs(" arguments but got "); eputd(expr.funktion.arguments.size); eputln();
@@ -624,8 +622,6 @@ function Parser.type_check_method_call(expr: Node*) {
 		eputs("Cannot access method on type "); eputs(type_to_string(parentType)); eputln();
 		exit(1);
 	}
-
-	funktion.funktion.used = true;
 
 	expr.funktion.parentType = parentType;
 
@@ -1419,10 +1415,6 @@ function Parser.type_check_top_level_declaration(node: Node*) {
 	if(node.type == NodeType::FUNCTION) {
 		if(!node.funktion.hasImplicitBody)
 			this.type_check_function(node);
-
-		if(node.funktion.name.equals(&mainName)) {
-			node.funktion.used = true;
-		}
 	}
 	else if(node.type == NodeType::DEFINE_GLOBAL_VAR) {
 		this.type_check_global_var(node);


### PR DESCRIPTION
Dead Code Elimination has been implemented. Tracing from `main`, the following are removed:
 - unused functions (no calls), including builtins
 - unused global variables (no access / assigning)
 - unused float/string literals (the containing function is DCE'd)

This can reduce the size of the final assembly file, especially when the program uses the standard library without using a lot of the functions. This includes the `Hello World` example:
```
import "std/io.zpr";

function main(): int {
  putsln("Hello, World!");
  return 0;
}
```
The final assembly file was reduced from `1323` lines to `165`.