### PR TITLE
Unsigned Integers

### DIFF
--- a/bootstrap/bootstrap_x86_64_linux.yasm
+++ b/bootstrap/bootstrap_x86_64_linux.yasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7352246cbb796c11c52948d9887d4deca037ef4f5d702044fd9783d93861550f
-size 643846
+oid sha256:8adf794f4badcce72032c85a5a89fe5cf4fd82f87ccc550e87431906a236b907
+size 658568

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -79,6 +79,11 @@ enum DataType {
 	I16,
 	I32,
 	I64,
+	UINT,
+	U8,
+	U16,
+	U32,
+	U64,
 	F64,
 	ANY,
 	STRUCT,
@@ -381,6 +386,11 @@ function data_type_to_string(type: DataType): i8* {
 		DataType::I16 -> return "i16";
 		DataType::I32 -> return "i32";
 		DataType::I64 -> return "i64";
+		DataType::INT -> return "int";
+		DataType::U8 -> return "u8";
+		DataType::U16 -> return "u16";
+		DataType::U32 -> return "u32";
+		DataType::U64 -> return "u64";
 		DataType::F64 -> return "f64";
 		DataType::ANY -> return "any";
 		DataType::ALIAS, DataType::UNRESOLVED, DataType::STRUCT, DataType::UNION -> {

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -39,6 +39,7 @@ enum NodeType {
 
 	RELATIVE,
 	INT_LITERAL,
+	UINT_LITERAL,
 	CHAR_LITERAL,
 	FLOAT_LITERAL,
 	STRING,
@@ -182,6 +183,7 @@ struct Node {
 
 			az: union {
 				integer: int;
+				uinteger: uint;
 				string: struct {
 					chars: i8*;
 					length: int;
@@ -510,6 +512,7 @@ function node_type_to_string(type: NodeType): i8* {
 		NodeType::INT_TO_FLOAT -> return "int to float";
 		NodeType::FLOAT_TO_INT -> return "float to int";
 		NodeType::INT_LITERAL -> return "int literal";
+		NodeType::UINT_LITERAL -> return "uint literal";
 		NodeType::CHAR_LITERAL -> return "char literal";
 		NodeType::STRING -> return "string";
 		NodeType::CALL -> return "call";
@@ -736,6 +739,9 @@ function print_ast_depth(node: Node*, depth: int) {
 		}
 		NodeType::INT_LITERAL -> {
 			puts("(literal "); putd(node.literal.az.integer); puts(")");
+		}
+		NodeType::UINT_LITERAL -> {
+			puts("(literal "); putu(node.literal.az.uinteger); puts(")");
 		}
 		NodeType::CHAR_LITERAL -> {
 			puts("(literal "); putc(node.literal.az.integer); puts(")");

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -325,7 +325,10 @@ function generate_binary_rax(expr: Node*, out: File*) {
 			out.putsln("    sal rax, cl");
 		}
 		NodeType::RSH -> {
-			out.putsln("    sar rax, cl");
+			if(expr.computedType.is_unsigned())
+				out.putsln("    shr rax, cl");
+			else
+				out.putsln("    sar rax, cl");
 		}
 		NodeType::EQUAL, NodeType::NOT_EQUAL, NodeType::LESS, NodeType::LESS_EQ, NodeType::GREATER, NodeType::GREATER_EQ -> {
 			out.putsln("    cmp rax, rcx");
@@ -649,6 +652,9 @@ function generate_expr_rax(expr: Node*, out: File*) {
 	when(expr.type) {
 		NodeType::INT_LITERAL -> {
 			out.puts("    mov rax, "); out.putd(expr.literal.az.integer); out.putln();
+		}
+		NodeType::UINT_LITERAL -> {
+			out.puts("    mov rax, "); out.putu(expr.literal.az.uinteger); out.putln();
 		}
 		NodeType::CHAR_LITERAL -> {
 			out.puts("    mov rax, "); out.putd(expr.literal.az.integer); out.putln();

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -294,12 +294,22 @@ function generate_binary_rax(expr: Node*, out: File*) {
 			out.putsln("    imul rax, rcx");
 		}
 		NodeType::DIV -> {
-			out.putsln("    cqo");
-			out.putsln("    idiv rcx");
+			if(expr.computedType.is_unsigned()) {
+				out.putsln("    mov rdx, 0");
+				out.putsln("    div rcx");
+			} else {
+				out.putsln("    cqo");
+				out.putsln("    idiv rcx");
+			}
 		}
 		NodeType::MOD -> {
-			out.putsln("    cqo");
-			out.putsln("    idiv rcx");
+			if(expr.computedType.is_unsigned()) {
+				out.putsln("    mov rdx, 0");
+				out.putsln("    div rcx");
+			} else {
+				out.putsln("    cqo");
+				out.putsln("    idiv rcx");
+			}
 			out.putsln("    mov rax, rdx");
 		}
 		NodeType::BWAND -> {
@@ -319,7 +329,7 @@ function generate_binary_rax(expr: Node*, out: File*) {
 		}
 		NodeType::EQUAL, NodeType::NOT_EQUAL, NodeType::LESS, NodeType::LESS_EQ, NodeType::GREATER, NodeType::GREATER_EQ -> {
 			out.putsln("    cmp rax, rcx");
-			out.puts("    set"); out.puts(cmp_suffix(expr.type)); out.putsln(" al");
+			out.puts("    set"); out.puts(expr.computedType.is_unsigned() ? ucmp_suffix(expr.type) : cmp_suffix(expr.type)); out.putsln(" al");
 			out.putsln("    movzx rax, al");
 		}
 		else -> {

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -75,11 +75,10 @@ function Parser.dce_expression(expr: Node*) {
 			variable.variable.used = true;
 		}
 		NodeType::SIZEOF,
-		NodeType::CHAR_LITERAL, NodeType::INT_LITERAL, NodeType::ACCESS_VAR -> {}
+		NodeType::CHAR_LITERAL, NodeType::INT_LITERAL, NodeType::UINT_LITERAL, NodeType::ACCESS_VAR -> {}
 		else -> {
 			eputs("dce_expression unsupported node - ");
 			eputsln(node_type_to_string(expr.type));
-			eputd(expr.type); eputln();
 			exit(1);
 		}
 	}

--- a/src/lexer.zpr
+++ b/src/lexer.zpr
@@ -109,6 +109,11 @@ function Lexer.identifier_type(): int {
 	if(this.match_keyword("sizeof")) return TokenType::SIZEOF;
 	if(this.match_keyword("struct")) return TokenType::STRUCT;
 	if(this.match_keyword("union")) return TokenType::UNION;
+	if(this.match_keyword("uint")) return TokenType::UINT;
+	if(this.match_keyword("u8")) return TokenType::U8;
+	if(this.match_keyword("u16")) return TokenType::U16;
+	if(this.match_keyword("u32")) return TokenType::U32;
+	if(this.match_keyword("u64")) return TokenType::U64;
 	if(this.match_keyword("var")) return TokenType::VAR;
 	if(this.match_keyword("void")) return TokenType::VOID;
 	if(this.match_keyword("when")) return TokenType::WHEN;

--- a/src/lexer.zpr
+++ b/src/lexer.zpr
@@ -151,6 +151,9 @@ function Lexer.number(): Token* {
 		while(is_digit(this.peek())) this.advance();
 		return this.make_token(TokenType::FLOAT_LITERAL);
 	}
+	else if(this.match('u') || this.match('U')) {
+		return this.make_token(TokenType::UINT_LITERAL);
+	}
 
 	return this.make_token(TokenType::INT_LITERAL);
 }

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -261,6 +261,12 @@ function Parser.parse_constant(): int {
 
 		return atoi(literal.start);
 	}
+	else if(this.match(TokenType::UINT_LITERAL)) {
+		var literal = this.previous;
+		if(this.error) return 0;
+
+		return atoui(literal.start);
+	}
 	else if(this.match(TokenType::CHAR_LITERAL)) {
 		var literal = this.previous;
 		if(this.error) return 0;
@@ -348,6 +354,16 @@ function Parser.parse_value(): Node* {
 		var literalNode = new_node(NodeType::INT_LITERAL, literal);
 		literalNode.literal.type = INT_TYPE;
 		literalNode.literal.az.integer = atoi(literal.start);
+
+		return literalNode;
+	}
+	else if(this.match(TokenType::UINT_LITERAL)) {
+		var literal = this.previous;
+		if(this.error) return null;
+
+		var literalNode = new_node(NodeType::UINT_LITERAL, literal);
+		literalNode.literal.type = UINT_TYPE;
+		literalNode.literal.az.uinteger = atoui(literal.start);
 
 		return literalNode;
 	}

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -205,31 +205,39 @@ function Parser.parse_type(): Type* {
 
 	var type = new_type();
 
-	if(this.previous.type == TokenType::INT) type.type = DataType::INT;
-	else if(this.previous.type == TokenType::I8) type.type = DataType::I8;
-	else if(this.previous.type == TokenType::I16) type.type = DataType::I16;
-	else if(this.previous.type == TokenType::I32) type.type = DataType::I32;
-	else if(this.previous.type == TokenType::I64) type.type = DataType::I64;
-	else if(this.previous.type == TokenType::F64) type.type = DataType::F64;
-	else if(this.previous.type == TokenType::ANY) type.type = DataType::ANY;
-	else if(this.previous.type == TokenType::IDENTIFIER) {
-		type.type = DataType::UNRESOLVED;
+	when(this.previous.type) {
+		TokenType::INT -> type.type = DataType::INT;
+		TokenType::I8 -> type.type = DataType::I8;
+		TokenType::I16 -> type.type = DataType::I16;
+		TokenType::I32 -> type.type = DataType::I32;
+		TokenType::I64 -> type.type = DataType::I64;
+		TokenType::UINT -> type.type = DataType::UINT;
+		TokenType::U8 -> type.type = DataType::U8;
+		TokenType::U16 -> type.type = DataType::U16;
+		TokenType::U32 -> type.type = DataType::U32;
+		TokenType::U64 -> type.type = DataType::U64;
+		TokenType::F64 -> type.type = DataType::F64;
+		TokenType::ANY -> type.type = DataType::ANY;
 
-		var name = this.previous;
+		TokenType::IDENTIFIER -> {
+			type.type = DataType::UNRESOLVED;
 
-		var nameSpace = new_namespace(null, null);
-		nameSpace.parts = new_vector();
+			var name = this.previous;
 
-		while(this.match(TokenType::COLON_COLON)) {
-			nameSpace.parts.push(name);
-			name = this.consume(TokenType::IDENTIFIER, "Expected identifier");	
+			var nameSpace = new_namespace(null, null);
+			nameSpace.parts = new_vector();
+
+			while(this.match(TokenType::COLON_COLON)) {
+				nameSpace.parts.push(name);
+				name = this.consume(TokenType::IDENTIFIER, "Expected identifier");	
+			}
+
+			this.bind_name(&type.name, name);
+			if(nameSpace.parts.size > 0) bind_to_namespace(&type.name, nameSpace);
 		}
-
-		this.bind_name(&type.name, name);
-		if(nameSpace.parts.size > 0) bind_to_namespace(&type.name, nameSpace);
-	}
-	else {
-		this.error("Expected type");
+		else -> {
+			this.error("Expected type");
+		}
 	}
 
 	while(this.match(TokenType::STAR)) {

--- a/src/token.zpr
+++ b/src/token.zpr
@@ -82,6 +82,11 @@ enum TokenType {
 	SIZEOF,
 	STRUCT,
 	UNION,
+	UINT,
+	U8,
+	U16,
+	U32,
+	U64,
 	VAR,
 	VOID,
 	WHEN,
@@ -177,6 +182,11 @@ function token_type_to_string(type: TokenType): i8* {
 		TokenType::SIZEOF -> return "sizeof";
 		TokenType::STRUCT -> return "struct";
 		TokenType::UNION -> return "union";
+		TokenType::UINT -> return "uint";
+		TokenType::U8 -> return "u8";
+		TokenType::U16 -> return "u16";
+		TokenType::U32 -> return "u32";
+		TokenType::U64 -> return "u64";
 		TokenType::VAR -> return "var";
 		TokenType::VOID -> return "void";
 		TokenType::WHEN -> return "when";

--- a/src/token.zpr
+++ b/src/token.zpr
@@ -53,6 +53,7 @@ enum TokenType {
 	RSH_EQ,
 
 	INT_LITERAL,
+	UINT_LITERAL,
 	CHAR_LITERAL,
 	FLOAT_LITERAL,
 	STRING,
@@ -153,6 +154,7 @@ function token_type_to_string(type: TokenType): i8* {
 		TokenType::RSH_EQ -> return ">>=";
 
 		TokenType::INT_LITERAL -> return "int-literal";
+		TokenType::UINT_LITERAL -> return "uint-literal";
 		TokenType::CHAR_LITERAL -> return "char-literal";
 		TokenType::FLOAT_LITERAL -> return "float-literal";
 		TokenType::STRING -> return "string";

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -847,6 +847,10 @@ function Parser.type_check_expr(expr: Node*) {
 		expr.computedType = INT_TYPE;
 		typeStack.push(INT_TYPE);
 	}
+	else if(expr.type == NodeType::UINT_LITERAL) {
+		expr.computedType = UINT_TYPE;
+		typeStack.push(UINT_TYPE);
+	}
 	else if(expr.type == NodeType::CHAR_LITERAL) {
 		expr.computedType = I8_TYPE;
 		typeStack.push(I8_TYPE);

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -12,11 +12,26 @@ var checkingLoop = false;
 
 function Type.is_integral(): bool {
 	return this.indirection == 0 && (
+		this.type == DataType::UINT||
+		this.type == DataType::U8  ||
+		this.type == DataType::U16 ||
+		this.type == DataType::U32 ||
+		this.type == DataType::U64 ||
 		this.type == DataType::INT ||
-		this.type == DataType::I8 ||
+		this.type == DataType::I8  ||
 		this.type == DataType::I16 ||
 		this.type == DataType::I32 ||
 		this.type == DataType::I64
+	);
+}
+
+function Type.is_unsigned(): bool {
+	return this.indirection == 0 && (
+		this.type == DataType::UINT||
+		this.type == DataType::U8  ||
+		this.type == DataType::U16 ||
+		this.type == DataType::U32 ||
+		this.type == DataType::U64
 	);
 }
 
@@ -88,6 +103,11 @@ function Type.size(): int {
 	if(this.type == DataType::I16) return 2;
 	if(this.type == DataType::I32) return 4;
 	if(this.type == DataType::I64) return 8;
+	if(this.type == DataType::UINT) return 8;
+	if(this.type == DataType::U8) return 1;
+	if(this.type == DataType::U16) return 2;
+	if(this.type == DataType::U32) return 4;
+	if(this.type == DataType::U64) return 8;
 	if(this.type == DataType::F64) return 8;
 	if(this.type == DataType::ANY) return 8;
 	if(this.type == DataType::STRUCT) {

--- a/src/types.zpr
+++ b/src/types.zpr
@@ -1,6 +1,7 @@
 import "src/ast.zpr";
 
 var INT_TYPE: Type*;
+var UINT_TYPE: Type*;
 var I8_TYPE: Type*;
 var STR_TYPE: Type*;
 var F64_TYPE: Type*;
@@ -26,6 +27,9 @@ function copy_type(a: Type*): Type* {
 function build_types() {
 	INT_TYPE = new_type();
 	INT_TYPE.type = DataType::INT;
+
+	UINT_TYPE = new_type();
+	UINT_TYPE.type = DataType::UINT;
 
 	I8_TYPE = new_type();
 	I8_TYPE.type = DataType::I8;

--- a/std/core.zpr
+++ b/std/core.zpr
@@ -32,6 +32,10 @@ function lseek(fd: int, offset: int, w: int): int {
 	return syscall3(SYS_lseek, fd, offset, w);
 }
 
+function time(): uint {
+	return syscall1(SYS_time, null);
+}
+
 // Memory
 
 var __malloc_buffer: i8[15728640]; // 15 * 1024 * 1024 - 15MB

--- a/std/io.zpr
+++ b/std/io.zpr
@@ -36,8 +36,7 @@ function fputc(fd: int, char: i8) {
 	write(fd, &char, 1);
 }
 
-// TODO: This function should take an unsigned integer, but they are not supported yet
-function fputu(fd: int, val: int) {
+function fputu(fd: int, val: uint) {
 	var buffer: i8[21];
 	uitoa(val, buffer);
 
@@ -106,7 +105,7 @@ function putc(char: i8) {
 	fputc(stdout, char);
 }
 
-function putu(val: int) {
+function putu(val: uint) {
 	fputu(stdout, val);
 }
 
@@ -136,7 +135,7 @@ function eputc(char: i8) {
 	fputc(stderr, char);
 }
 
-function eputu(val: int) {
+function eputu(val: uint) {
 	fputu(stderr, val);
 }
 
@@ -215,7 +214,7 @@ function File.putc(char: i8) {
 	this.write(&char, 1);
 }
 
-function File.putu(val: int) {
+function File.putu(val: uint) {
 	var buffer: i8[21];
 	uitoa(val, buffer);
 

--- a/std/rand.zpr
+++ b/std/rand.zpr
@@ -1,0 +1,10 @@
+var __std_rand_seed: uint = 1u;
+
+function srand(seed: uint) {
+	__std_rand_seed = seed;
+}
+
+function rand(): uint {
+	__std_rand_seed = 6364136223846793005*__std_rand_seed + 1;
+	return __std_rand_seed >> 33;
+}

--- a/std/string.zpr
+++ b/std/string.zpr
@@ -99,6 +99,20 @@ function atoi(str: i8*): int {
 	return num * sign;
 }
 
+function atoui(str: i8*): uint {
+	var num: uint = 0;
+
+	var i = 0;
+
+	while('0' <= str[i] && str[i] <= '9') {
+		num *= 10;
+		num += str[i] - '0';
+		++i;
+	}
+
+	return num;
+}
+
 // Splits a string on the first instance of a given character
 // Params:
 //  - str => the source string

--- a/tests/core.sh
+++ b/tests/core.sh
@@ -1599,3 +1599,31 @@ function main(): int {
 "
 
 echo " Done"
+
+echo -n "Unsigned: "
+
+assert_stdout "1" "
+function main(): int {
+	var x: uint = -1;
+	printu(x > 1);
+	return 0;
+}
+"
+
+assert_stdout "9223372036854775807" "
+function main(): int {
+	var x: uint = -1;
+	printu(x / 2);
+	return 0;
+}
+"
+
+assert_stdout "20" "
+function main(): int {
+	var x = 20u;
+	printu(x);
+	return 0;
+}
+"
+
+echo " Done"


### PR DESCRIPTION
Adds 5 new types, which are all unsigned varients of the standard int types:
- `uint`
- `u8`
- `u16`
- `u32`
- `u64`
Adds support for unsigned literals, e.g., `128u` or `128U`.

The unsigned integers perform the correct varient of the arithemetic operations `/`, `%`, and `>>`.
E.g., signed division uses `idiv` and unsigned division uses `div`.