### PR TITLE
Character / String Escape Sequences

### DIFF
--- a/bootstrap/bootstrap_x86_64_linux.yasm
+++ b/bootstrap/bootstrap_x86_64_linux.yasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ef1c962ba365bb9ad4de47bafb865a9f99ecab08a1a6aafc42979e02fe7c26b9
-size 665642
+oid sha256:2ea0a73f0866a9a023311ef493663edb32b814f40f0bd499d16ec838a79d5227
+size 681674

--- a/examples/gol.zpr
+++ b/examples/gol.zpr
@@ -92,9 +92,8 @@ function print_board(board: i8*) {
 }
 
 function move_cursor_start() {
-	// TODO: Use escape characters for this - \x1b[
-	putc(27); puts("["); putu(ROWS); puts("A");
-	putc(27); puts("["); putu(COLUMNS); puts("D");
+	puts("\x1b["); putu(ROWS); puts("A");
+	puts("\x1b["); putu(COLUMNS); puts("D");
 }
 
 function set_blinker(board: i8*) {

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -1072,6 +1072,40 @@ function Parser.generate_top_level_declaration(node: Node*, out: File*) {
 	}
 }
 
+function Parser.generate_string(str: Node*, out: File*) {
+	var inQuotes = false;
+	var first = true;
+
+	for(var i = 0; str.literal.az.string.chars[i]; ++i) {
+		var c = str.literal.az.string.chars[i];
+
+		// Standard ascii range + space, without double quotes
+		if(('!' <= c && c <= '~' && c != '\"') || c == ' ') {
+			if(!inQuotes) {
+				inQuotes = true;
+				if(!first) out.puts(", ");
+				out.putc('\"');
+			}
+			out.putc(c);
+		}
+		else {
+			if(inQuotes) {
+				inQuotes = false;
+				out.putc('\"');
+			}
+			if(!first) out.puts(", ");
+			out.putu(c);
+		}
+		first = false;
+	}
+
+	if(inQuotes) {
+		out.putc('\"');
+	}
+
+	out.putsln(", 0");
+}
+
 function Parser.generate_program(ast: Node*, out: File*) {
 	out.putsln("section .text");
 	
@@ -1168,8 +1202,7 @@ function Parser.generate_program(ast: Node*, out: File*) {
 
 			if(!str.literal.used) continue;
 
-			out.puts("_S"); out.putd(str.literal.az.string.id); out.puts(": db "); out.putc('"'); out.puts(str.literal.az.string.chars);
-			out.putc('"'); out.putsln(", 0");
+			out.puts("_S"); out.putd(str.literal.az.string.id); out.puts(": db "); this.generate_string(str, out);
 		}
 
 		for(var i = 0; i < this.floats.size; ++i) {

--- a/src/lexer.zpr
+++ b/src/lexer.zpr
@@ -167,12 +167,11 @@ function Lexer.character(): Token* {
 	if(this.is_at_end()) return this.error_token("Expected character literal");
 	this.advance();
 
-	//TODO Character escapes
-	if(this.current[-1] == 92) {
+	if(this.current[-1] == '\\') {
 		this.advance();
 	}
 
-	if(!this.match(39)) return this.error_token("Expected closing single quote");
+	if(!this.match('\'')) return this.error_token("Expected closing single quote");
 	return this.make_token(TokenType::CHAR_LITERAL);
 }
 
@@ -267,8 +266,7 @@ function Lexer.next(): Token* {
 	if(is_alpha(c)) return this.identifier();
 	if(is_digit(c)) return this.number();
 
-	//TODO Character escape
-	if(c == 39) return this.character();
+	if(c == '\'') return this.character();
 	if(c == '"') return this.string();
 
 	when(c) {

--- a/src/lexer.zpr
+++ b/src/lexer.zpr
@@ -69,16 +69,6 @@ function Lexer.error_token(message: i8*): Token* {
 	return token;
 }
 
-function is_digit(c: i8): int {
-	return '0' <= c && c <= '9';
-}
-
-function is_alpha(c: i8): int {
-	return ('a' <= c && c <= 'z') ||
-	       ('A' <= c && c <= 'Z') ||
-		   c == '_';
-}
-
 function Lexer.match_keyword(keyword: i8*): int {
 	var length = strlen(keyword);
 	return (this.current as int) - (this.start as int) == length && memeq(this.start, keyword, length);
@@ -159,7 +149,7 @@ function Lexer.number(): Token* {
 }
 
 function Lexer.identifier(): Token* {
-	while(is_alpha(this.peek()) || is_digit(this.peek())) this.advance();
+	while(is_alpha(this.peek()) || is_digit(this.peek()) || this.peek() == '_') this.advance();
 	return this.make_token(this.identifier_type());
 }
 
@@ -169,6 +159,12 @@ function Lexer.character(): Token* {
 
 	if(this.current[-1] == '\\') {
 		this.advance();
+
+		if(this.current[-1] == 'x' || this.current[-1] == 'X') {
+			this.advance();
+			if(this.is_at_end()) return this.error_token("Invalid character escape");
+			this.advance();
+		}
 	}
 
 	if(!this.match('\'')) return this.error_token("Expected closing single quote");
@@ -263,7 +259,7 @@ function Lexer.next(): Token* {
 	
 	var c = this.advance();
 
-	if(is_alpha(c)) return this.identifier();
+	if(is_alpha(c) || c == '_') return this.identifier();
 	if(is_digit(c)) return this.number();
 
 	if(c == '\'') return this.character();

--- a/src/lexer.zpr
+++ b/src/lexer.zpr
@@ -172,7 +172,8 @@ function Lexer.character(): Token* {
 }
 
 function Lexer.string(): Token* {
-	while(!this.is_at_end() && this.peek() != '"') {
+	while(!(this.peek() == '"' && this.current[-1] != '\\') && !this.is_at_end()) {
+		if(this.peek() == '\n') ++this.line;
 		this.advance();
 	}
 

--- a/src/lexer.zpr
+++ b/src/lexer.zpr
@@ -166,6 +166,12 @@ function Lexer.identifier(): Token* {
 function Lexer.character(): Token* {
 	if(this.is_at_end()) return this.error_token("Expected character literal");
 	this.advance();
+
+	//TODO Character escapes
+	if(this.current[-1] == 92) {
+		this.advance();
+	}
+
 	if(!this.match(39)) return this.error_token("Expected closing single quote");
 	return this.make_token(TokenType::CHAR_LITERAL);
 }
@@ -261,6 +267,7 @@ function Lexer.next(): Token* {
 	if(is_alpha(c)) return this.identifier();
 	if(is_digit(c)) return this.number();
 
+	//TODO Character escape
 	if(c == 39) return this.character();
 	if(c == '"') return this.string();
 

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -268,6 +268,13 @@ function Parser.escape_character(literal: Token*): i8 {
 		'\\' -> return '\\';
 		'\'' -> return '\'';
 		'\"' -> return '\"';
+
+		'x', 'X' -> {
+			if(!is_hex_digit(literal.start[3]) || !is_hex_digit(literal.start[4])) {
+				this.error_at_token(literal, "Invalid hexadecimal escape");
+			}
+			return hex_numeral(literal.start[3])*16 + hex_numeral(literal.start[4]);
+		}
 	}
 	this.error_at_token(literal, "Invalid escape sequence");
 	return 0;

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -256,6 +256,23 @@ function Parser.parse_type(): Type* {
 	return type;
 }
 
+function Parser.escape_character(literal: Token*): i8 {
+	if(literal.start[1] != 92) {
+		return literal.start[1];
+	}
+	when(literal.start[2]) {
+		'n' -> return 10;
+		'r' -> return 13;
+		't' -> return 9;
+		'v' -> return 11;
+		92 -> return 92;
+		39 -> return 39;
+		34 -> return 34;
+	}
+	this.error_at_token(literal, "Invalid escape sequence");
+	return 0;
+}
+
 function Parser.eval_constexpr(expr: Node*): int {
 	when(expr.type) {
 		// Note: only signed integers are supported as constants, so uint becomes int
@@ -391,7 +408,7 @@ function Parser.parse_value(): Node* {
 
 		var literalNode = new_node(NodeType::CHAR_LITERAL, literal);
 		literalNode.literal.type = I8_TYPE;
-		literalNode.literal.az.integer = literal.start[1];
+		literalNode.literal.az.integer = this.escape_character(literal);
 
 		return literalNode;
 	}

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -303,6 +303,7 @@ function Parser.escape_string(literal: Token*, buf: i8*) {
 		}
 		
 		buf[bufIdx] = this.escape_literal(literal, i + 2);
+		if(literal.start[i + 2] == 'x' || literal.start[i + 2] == 'X') i += 2;
 		++i;
 		++bufIdx;
 	}

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -257,17 +257,17 @@ function Parser.parse_type(): Type* {
 }
 
 function Parser.escape_character(literal: Token*): i8 {
-	if(literal.start[1] != 92) {
+	if(literal.start[1] != '\\') {
 		return literal.start[1];
 	}
 	when(literal.start[2]) {
-		'n' -> return 10;
-		'r' -> return 13;
-		't' -> return 9;
-		'v' -> return 11;
-		92 -> return 92;
-		39 -> return 39;
-		34 -> return 34;
+		'n' -> return '\n';
+		'r' -> return '\r';
+		't' -> return '\t';
+		'v' -> return '\v';
+		'\\' -> return '\\';
+		'\'' -> return '\'';
+		'\"' -> return '\"';
 	}
 	this.error_at_token(literal, "Invalid escape sequence");
 	return 0;

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -256,11 +256,9 @@ function Parser.parse_type(): Type* {
 	return type;
 }
 
-function Parser.escape_character(literal: Token*): i8 {
-	if(literal.start[1] != '\\') {
-		return literal.start[1];
-	}
-	when(literal.start[2]) {
+function Parser.escape_literal(literal: Token*, index: int): int {
+	when(literal.start[index]) {
+		'0' -> return '\0';
 		'n' -> return '\n';
 		'r' -> return '\r';
 		't' -> return '\t';
@@ -270,14 +268,45 @@ function Parser.escape_character(literal: Token*): i8 {
 		'\"' -> return '\"';
 
 		'x', 'X' -> {
-			if(!is_hex_digit(literal.start[3]) || !is_hex_digit(literal.start[4])) {
+			if(!is_hex_digit(literal.start[index + 1]) || !is_hex_digit(literal.start[index + 2])) {
 				this.error_at_token(literal, "Invalid hexadecimal escape");
 			}
-			return hex_numeral(literal.start[3])*16 + hex_numeral(literal.start[4]);
+			return hex_numeral(literal.start[index + 1])*16 + hex_numeral(literal.start[index + 2]);
 		}
 	}
+
+	return -1;
+}
+
+function Parser.escape_character(literal: Token*): i8 {
+	if(literal.start[1] != '\\') {
+		return literal.start[1];
+	}
+	
+	var value = this.escape_literal(literal, 2);
+
+	if(value != -1) return value;
+
 	this.error_at_token(literal, "Invalid escape sequence");
 	return 0;
+}
+
+function Parser.escape_string(literal: Token*, buf: i8*) {
+	var bufIdx = 0;
+	for(var i = 0; i < literal.length - 2; ++i) {
+		var char = literal.start[i + 1];
+
+		if(char != '\\') {
+			buf[bufIdx] = char;
+			++bufIdx;
+			continue;
+		}
+		
+		buf[bufIdx] = this.escape_literal(literal, i + 2);
+		++i;
+		++bufIdx;
+	}
+	buf[bufIdx] = '\0';
 }
 
 function Parser.eval_constexpr(expr: Node*): int {
@@ -444,8 +473,7 @@ function Parser.parse_value(): Node* {
 		literalNode.literal.type = STR_TYPE;
 
 		var buf = malloc(literal.length - 2 + 1);
-		memcpy(buf, &literal.start[1], literal.length - 2);
-		buf[literal.length - 2] = 0;
+		this.escape_string(literal, buf);
 
 		literalNode.literal.az.string.chars = buf;
 		literalNode.literal.az.string.length = literal.length - 2;

--- a/std/io.zpr
+++ b/std/io.zpr
@@ -18,7 +18,7 @@ function assert(condition: bool, message: i8*) {
 // ========== fput family ==========
 
 function fputln(fd: int) {
-	var n = 10;
+	var n = '\n';
 	write(fd, &n, 1);
 }
 
@@ -197,7 +197,7 @@ function File.write(buf: any*, size: int) {
 }
 
 function File.putln() {
-	this.putc(10);
+	this.putc('\n');
 }
 
 function File.puts(str: i8*) {

--- a/std/string.zpr
+++ b/std/string.zpr
@@ -175,3 +175,25 @@ function strcpy(dst: i8*, src: i8*) {
 	var length = strlen(src);
 	memcpy(dst, src, length + 1);
 }
+
+function is_digit(c: i8): bool {
+	return '0' <= c && c <= '9';
+}
+
+function is_alpha(c: i8): bool {
+	return ('a' <= c && c <= 'z') ||
+	       ('A' <= c && c <= 'Z');
+}
+
+function is_hex_digit(c: i8): bool {
+	return is_digit(c) || 
+		('a' <= c && c <= 'f') ||
+		('A' <= c && c <= 'F');
+}
+
+function hex_numeral(c: i8): i8 {
+	if('a' <= c && c <= 'f') return 15 - ('f' - c); 
+	if('A' <= c && c <= 'F') return 15 - ('F' - c);
+
+	return c - '0'; 
+}

--- a/tests/core.sh
+++ b/tests/core.sh
@@ -1656,3 +1656,56 @@ function main(): int {
 "
 
 echo " Done"
+
+echo -n "Escapes: "
+
+assert_stdout "dog
+cat" "
+import \"std/io.zpr\";
+
+function main(): int {
+	puts(\"dog\"); putc('\\n'); puts(\"cat\");
+	return 0;
+}
+"
+
+assert_stdout "A" "
+import \"std/io.zpr\";
+
+function main(): int {
+	putc('\x41');
+	return 0;
+}
+"
+
+assert_stdout "Hello \"Jeff\"" "
+import \"std/io.zpr\";
+
+function main(): int {
+	puts(\"Hello \\\"Jeff\\\"\");
+	return 0;
+}
+"
+
+assert_stdout "Hello
+World" "
+import \"std/io.zpr\";
+
+function main(): int {
+	puts(\"Hello\\nWorld\");
+	return 0;
+}
+"
+
+assert_stdout "A" "
+import \"std/io.zpr\";
+
+function main(): int {
+
+	putsln(\"\x41\");
+
+	return 0;
+}
+"
+
+echo " Done"


### PR DESCRIPTION
Allows escape sequences, such as `\n`, to be used in character and string literals.

Currently supported are the following literals:
- `\0`
- `\n`
- `\r`
- `\t`
- `\v`
- `\\`
- `\'`
- `\"`
- `\xhh`, where `hh` is the hexadecimal encoding of the byte produced

Note that `\xhh` can use either a lowercase 'x' or uppercase 'X', but the rest of the escapes must be lowercase.