### PR TITLE
Function Overloading

### DIFF
--- a/bootstrap/bootstrap_x86_64_linux.yasm
+++ b/bootstrap/bootstrap_x86_64_linux.yasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:852b77b005f74f5d5bbb79693b7d208a1d5adf47a0aab8cb82078b83aebf8399
-size 776427
+oid sha256:a046520ff197342caa21a4575939e553b34ec6ada8e66100986abff73cd57cae
+size 852845

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -1,4 +1,5 @@
 import "std/vector.zpr";
+import "std/map.zpr";
 
 // Updating this list requires updating node_type_to_string and print_ast_depth
 enum NodeType {
@@ -105,7 +106,7 @@ struct Type {
 
 	name: Name;
 	fields: Vector*;
-	methods: Vector*;
+	methods: std::map::HashMap*;
 	aliased: Type*;
 
 	built: bool;
@@ -209,6 +210,7 @@ struct Node {
 
 			value: Node*;
 			arguments: Vector*;
+			argTypes: Vector*;
 
 			stackOffset: int;
 			unionField: int;
@@ -251,6 +253,7 @@ struct Node {
 		constructor: struct {
 			type: Type*;
 			shouldConstruct: bool;
+			argTypes: Vector*;
 			union {
 				arguments: Vector*;
 				array: struct {
@@ -407,6 +410,32 @@ function File.put_namespace_name(namespaceName: Namespace*) {
 		this.put_token_string(namespaceName.parts.at(i));
 		if(i != namespaceName.parts.size - 1) this.puts("_");
 	}
+}
+
+function Type.add_method(method: Node*) {
+	var nameStr = method.funktion.name.to_string();
+
+	var found = false;
+	var list = this.methods.get(nameStr, &found) as Vector*;
+
+	if(found) {
+		list.push(method);
+	}
+	else {
+		list = new_vector();
+		list.push(method);
+		this.methods.set(nameStr, list);
+	}
+}
+
+function Type.get_method(name: Name*, found: bool*): Vector* {
+	var nameStr = name.to_string();
+
+	var list = this.methods.get(nameStr, found) as Vector*;
+
+	delete[] nameStr;
+
+	return list;
 }
 
 function data_type_to_string(type: DataType): i8* {

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -433,8 +433,6 @@ function Type.get_method(name: Name*, found: bool*): Vector* {
 
 	var list = this.methods.get(nameStr, found) as Vector*;
 
-	delete[] nameStr;
-
 	return list;
 }
 

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -164,6 +164,7 @@ struct Node {
 			parentType: Type*;
 
 			arguments: Vector*;
+			argTypes: Vector*;
 
 			localVariableStackOffset: int;
 

--- a/src/builtin.zpr
+++ b/src/builtin.zpr
@@ -13,7 +13,7 @@ function add_implicit_printu_function(): Node* {
 	var valTok = synthetic_token(TokenType::IDENTIFIER, "value");
 	var val = new_node(NodeType::DEFINE_VAR, valTok);
 	val.variable.name.name = valTok;
-	val.variable.type = INT_TYPE;
+	val.variable.type = UINT_TYPE;
 	funktion.funktion.arguments.push(val);
 
 	funktion.funktion.returnType = VOID_TYPE;
@@ -70,7 +70,7 @@ function parser_builtin_functions(): Vector* {
 }
 
 function generate_implicit_printu_impl(out: File*) {
-	out.putsln("_FZprintu:");
+	out.putsln("_FUZprintu:");
 	out.putsln("		sub     rsp, 40");
 	out.putsln("		mov     eax, 10");
 	out.putsln("		mov     esi, 19");
@@ -114,9 +114,14 @@ function generate_builtin_functions(out: File*) {
 	for(var i = 0; i <= 5; ++i) {
 		if(!(builtinFunctions.at(i + 1) as Node*).funktion.used) continue;
 
-		out.puts("_FZsyscall"); out.putd(i); out.putsln(":");
+		out.puts("_F"); out.puts("I");
+		for(var arg = 0; arg < i; ++arg) {
+			out.puts("A");
+		}
+		out.puts("Zsyscall");
+		out.putd(i); out.putsln(":");
 
-		for(var arg = 0; arg <= i; arg = arg + 1) {
+		for(var arg = 0; arg <= i; ++arg) {
 			out.puts("    mov "); out.puts(SYS_REGISTERS[arg]); out.puts(", "); out.putsln(ARG_REGISTERS[arg]);
 		}
 		out.putsln("    syscall");
@@ -125,7 +130,7 @@ function generate_builtin_functions(out: File*) {
 
 	if(!(builtinFunctions.at(6 + 1) as Node*).funktion.used) return;
 
-	out.putsln("_FZsyscall6:");
+	out.putsln("_FIAAAAAAZsyscall6:");
 	out.putsln("    push rbp");
 	out.putsln("    mov rbp, rsp");
 

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -107,6 +107,37 @@ function ucmp_suffix(type: int): i8* {
 	return null;
 }
 
+function File.put_arguments(arguments: Vector*) {
+	for(var i = 0; i < arguments.size; ++i) {
+		var type: Type* = arguments.at(i);
+
+		when(type.type) {
+			DataType::VOID -> this.puts("V");
+			DataType::INT -> this.puts("I");
+			DataType::I8 -> this.puts("j");
+			DataType::I16 -> this.puts("J");
+			DataType::I32 -> this.puts("l");
+			DataType::I64 -> this.puts("L");
+			DataType::UINT -> this.puts("U");
+			DataType::U8 -> this.puts("v");
+			DataType::U16 -> this.puts("V");
+			DataType::U32 -> this.puts("w");
+			DataType::U64 -> this.puts("W");
+			DataType::F64 -> this.puts("F");
+			DataType::ANY -> this.puts("A");
+			DataType::STRUCT, DataType::UNION -> {
+				this.put_name(&type.name);
+				this.puts("$");
+			}
+			else -> {
+				assert(0, "Unreachable - File.put_arguments");
+			}
+		}
+
+		for(var p = 0; p < type.indirection; ++p) this.puts("P");
+	}
+}
+
 function generate_addrof(expr: Node*, out: File*) {
 	when(expr.unary.lvalue) {
 		LValue::LOCAL -> {
@@ -398,7 +429,7 @@ function generate_call(expr: Node*, out: File*) {
 	intRegistersInUse -= localIntRegUse;
 	floatRegistersInUse -= localFloatRegUse;
 
-	out.puts("    call _F"); out.put_name(&expr.funktion.name); out.putln();
+	out.puts("    call _F"); out.put_arguments(expr.funktion.argTypes); out.put_name(&expr.funktion.name); out.putln();
 
 	for(var i = 0; i < intRegistersInUse; ++i) {
 		out.puts("    pop "); out.putsln(INT_ARG_REGISTERS[intRegistersInUse - i - 1]);
@@ -669,7 +700,7 @@ function generate_post_decrement(expr: Node*, out: File*) {
 function generate_new(expr: Node*, out: File*) {
 	// Typecheck should verify that malloc exists with the correct signature
 	out.puts("    mov rdi, "); out.putu(expr.constructor.type.size()); out.putln();
-	out.putsln("    call _FZmalloc");
+	out.putsln("    call _FUZmalloc");
 
 	if(expr.constructor.shouldConstruct) {
 		var constructorTok = synthetic_token(TokenType::IDENTIFIER, "constructor");
@@ -690,7 +721,7 @@ function generate_new_array(expr: Node*, out: File*) {
 	}
 	out.puts("    imul rax, "); out.putu(expr.constructor.type.size()); out.putln();
 	out.putsln("    mov rdi, rax");
-	out.putsln("    call _FZmalloc");
+	out.putsln("    call _FUZmalloc");
 
 	// Construct a for-loop inline
 	if(expr.constructor.shouldConstruct) {
@@ -1051,7 +1082,7 @@ function generate_define_var(stmt: Node*, out: File*) {
 function generate_delete(stmt: Node*, out: File*) {
 	generate_expr(stmt.deconstructor.value, out);
 	out.putsln("    mov rdi, rax");
-	out.putsln("    call _FZfree");
+	out.putsln("    call _FAPZfree");
 
 	if(stmt.deconstructor.shouldDeconstruct) {
 		var deconstructorTok = synthetic_token(TokenType::IDENTIFIER, "deconstructor");
@@ -1076,7 +1107,7 @@ function generate_delete_array(stmt: Node*, out: File*) {
 		var arrayLengthFunc = parser.resolve_get_array_length_function();
 		out.putsln("mov rdi, rax");
 		out.puts("mov rsi, "); out.putu(stmt.deconstructor.elementType.size()); out.putln();
-		out.puts("call _F"); out.put_name(&arrayLengthFunc.funktion.name); out.putln();
+		out.puts("call _FAPU"); out.put_name(&arrayLengthFunc.funktion.name); out.putln();
 
 		out.putsln("push rax");
 
@@ -1130,7 +1161,7 @@ function generate_delete_array(stmt: Node*, out: File*) {
 	}
 	
 	out.putsln("    mov rdi, rax");
-	out.putsln("    call _FZfree");
+	out.putsln("    call _FAPZfree");
 }
 
 function generate_return(stmt: Node*, out: File*) {
@@ -1234,8 +1265,8 @@ function generate_block(block: Node*, out: File*) {
 
 function generate_function(funktion: Node*, out: File*) {
 	if(!funktion.funktion.isMethod) {
-		out.puts("global _F"); out.put_name(&funktion.funktion.name); out.putln();
-		out.puts("_F"); out.put_name(&funktion.funktion.name); out.putsln(":");
+		out.puts("global _F"); out.put_arguments(funktion.funktion.argTypes); out.put_name(&funktion.funktion.name); out.putln();
+		out.puts("_F"); out.put_arguments(funktion.funktion.argTypes); out.put_name(&funktion.funktion.name); out.putsln(":");
 	}
 	else {
 		out.puts("global _M"); out.put_name(&funktion.funktion.parentType.name); 
@@ -1414,7 +1445,14 @@ function Parser.generate_program(ast: Node*, out: File*) {
 	out.putsln("    pop rdi");
 	out.putsln("    mov rsi, rsp");
 
-	out.putsln("    call _FZmain");
+	// Required as main's signature may vary
+	var mainTok = synthetic_token(TokenType::IDENTIFIER, "main");
+	var mainName: Name;
+	this.bind_name(&mainName, mainTok);
+	var mainFuncs = this.lookup_function(&mainName);
+	var main: Node* = mainFuncs.at(0);
+
+	out.puts("    call _F"); out.put_arguments(main.funktion.argTypes); out.putsln("Zmain");
 	out.putsln("    mov rdi, rax");
 	out.putsln("    mov rax, 60");
 	out.putsln("    syscall");

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -441,7 +441,7 @@ function generate_call(expr: Node*, out: File*) {
 	}
 }
 
-function generate_method_call(parent: Node*, parentType: Type*, name: Name*, arguments: Vector*, out: File*) {
+function generate_method_call(parent: Node*, parentType: Type*, name: Name*, arguments: Vector*, argTypes: Vector*, out: File*) {
 	for(var i = 0; i < intRegistersInUse; ++i) {
 		out.puts("    push "); out.putsln(INT_ARG_REGISTERS[i]);
 	}
@@ -493,7 +493,9 @@ function generate_method_call(parent: Node*, parentType: Type*, name: Name*, arg
 	intRegistersInUse -= localIntRegUse;
 	floatRegistersInUse -= localFloatRegUse;
 
-	out.puts("    call _M"); out.put_name(&parentType.name); out.puts("_"); out.put_name(name);
+	out.puts("    call _M"); 
+	if(argTypes != null) out.put_arguments(argTypes);
+	out.put_name(&parentType.name); out.puts("_"); out.put_name(name);
 	out.putln();
 
 	for(var i = 0; i < intRegistersInUse; ++i) {
@@ -507,7 +509,7 @@ function generate_method_call(parent: Node*, parentType: Type*, name: Name*, arg
 }
 
 function generate_call_method(expr: Node*, out: File*) {
-	generate_method_call(expr.funktion.parent, expr.funktion.parentType, &expr.funktion.name, expr.funktion.arguments, out);
+	generate_method_call(expr.funktion.parent, expr.funktion.parentType, &expr.funktion.name, expr.funktion.arguments, expr.funktion.argTypes, out);
 }
 
 function generate_ternary(expr: Node*, out: File*) {
@@ -708,7 +710,7 @@ function generate_new(expr: Node*, out: File*) {
 		parser.bind_name(&constructorName, constructorTok);
 
 		out.putsln("    push rax");
-		generate_method_call(null, expr.constructor.type, &constructorName, expr.constructor.arguments, out);
+		generate_method_call(null, expr.constructor.type, &constructorName, expr.constructor.arguments, expr.constructor.argTypes, out);
 		out.putsln("    pop rax");
 	}
 }
@@ -750,7 +752,7 @@ function generate_new_array(expr: Node*, out: File*) {
 		out.puts("    jnb .l"); out.putu(loopEnd); out.putln(); // exit the loop if i >= length
 
 		// address (offsetted) is already in rax at this point
-		generate_method_call(null, expr.constructor.type, &constructorName, null, out);
+		generate_method_call(null, expr.constructor.type, &constructorName, null, null, out);
 
 		// Set registers as such:
 		// rcx - i
@@ -1075,7 +1077,7 @@ function generate_define_var(stmt: Node*, out: File*) {
 
 		out.puts("    lea rax, [rbp-"); out.putd(stmt.variable.stackOffset); out.putsln("]");
 
-		generate_method_call(null, stmt.variable.type, &constructorName, stmt.variable.arguments, out);
+		generate_method_call(null, stmt.variable.type, &constructorName, stmt.variable.arguments, stmt.variable.argTypes, out);
 	}
 }
 
@@ -1134,7 +1136,7 @@ function generate_delete_array(stmt: Node*, out: File*) {
 		out.puts("    jnb .l"); out.putu(loopEnd); out.putln(); // exit the loop if i >= length
 
 		// address (offsetted) is already in rax at this point
-		generate_method_call(null, stmt.deconstructor.elementType, &deconstructorName, null, out);
+		generate_method_call(null, stmt.deconstructor.elementType, &deconstructorName, null, null, out);
 
 		// Set registers as such:
 		// rcx - i
@@ -1269,10 +1271,10 @@ function generate_function(funktion: Node*, out: File*) {
 		out.puts("_F"); out.put_arguments(funktion.funktion.argTypes); out.put_name(&funktion.funktion.name); out.putsln(":");
 	}
 	else {
-		out.puts("global _M"); out.put_name(&funktion.funktion.parentType.name); 
+		out.puts("global _M"); out.put_arguments(funktion.funktion.argTypes); out.put_name(&funktion.funktion.parentType.name); 
 		out.puts("_"); out.put_name(&funktion.funktion.name); out.putln();
 
-		out.puts("_M"); out.put_name(&funktion.funktion.parentType.name);
+		out.puts("_M"); out.put_arguments(funktion.funktion.argTypes); out.put_name(&funktion.funktion.parentType.name);
 		out.puts("_"); out.put_name(&funktion.funktion.name); out.putsln(":");
 	}
 

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -183,6 +183,7 @@ function Parser.dce_statement(stmt: Node*) {
 				var constructorName: Name;
 				this.bind_name(&constructorName, constructorTok);
 
+				//TODO THIS IS NULL
 				var constructor = stmt.variable.type.lookup_method_with_arguments(&constructorName, stmt.variable.argTypes);
 				if(!constructor.funktion.dced) {
 					constructor.funktion.dced = true;

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -30,7 +30,7 @@ function Parser.dce_expression(expr: Node*) {
 		}
 		NodeType::CALL_METHOD -> {
 			this.dce_expression(expr.funktion.parent);
-			var funktion = expr.funktion.parentType.lookup_method(&expr.funktion.name);
+			var funktion = expr.funktion.parentType.lookup_method_with_arguments(&expr.funktion.name, expr.funktion.argTypes);
 
 			for(var i = 0; i < expr.funktion.arguments.size; ++i) {
 				this.dce_expression(expr.funktion.arguments.at(i));
@@ -85,7 +85,7 @@ function Parser.dce_expression(expr: Node*) {
 				var constructorName: Name;
 				this.bind_name(&constructorName, constructorTok);
 
-				var constructor = expr.constructor.type.lookup_method(&constructorName);
+				var constructor = expr.constructor.type.lookup_method_with_arguments(&constructorName, expr.constructor.argTypes);
 				if(!constructor.funktion.dced) {
 					constructor.funktion.dced = true;
 					this.dce_function(constructor);
@@ -105,7 +105,8 @@ function Parser.dce_expression(expr: Node*) {
 				var constructorName: Name;
 				this.bind_name(&constructorName, constructorTok);
 
-				var constructor = expr.constructor.type.lookup_method(&constructorName);
+				var argTypes = new_vector();
+				var constructor = expr.constructor.type.lookup_method_with_arguments(&constructorName, argTypes);
 				if(!constructor.funktion.dced) {
 					constructor.funktion.dced = true;
 					this.dce_function(constructor);
@@ -137,7 +138,8 @@ function Parser.dce_block(block: Node*) {
 		var deconstructorName: Name;
 		this.bind_name(&deconstructorName, deconstructorTok);
 
-		var deconstructor = variable.variable.type.lookup_method(&deconstructorName);
+		var argTypes = new_vector();
+		var deconstructor = variable.variable.type.lookup_method_with_arguments(&deconstructorName, argTypes);
 
 		if(deconstructor != null && !deconstructor.funktion.dced) {
 			deconstructor.funktion.dced = true;
@@ -181,7 +183,7 @@ function Parser.dce_statement(stmt: Node*) {
 				var constructorName: Name;
 				this.bind_name(&constructorName, constructorTok);
 
-				var constructor = stmt.variable.type.lookup_method(&constructorName);
+				var constructor = stmt.variable.type.lookup_method_with_arguments(&constructorName, stmt.variable.argTypes);
 				if(!constructor.funktion.dced) {
 					constructor.funktion.dced = true;
 					this.dce_function(constructor);
@@ -216,7 +218,8 @@ function Parser.dce_statement(stmt: Node*) {
 				var deconstructorName: Name;
 				this.bind_name(&deconstructorName, deconstructorTok);
 
-				var deconstructor = stmt.unary.computedType.lookup_method(&deconstructorName);
+				var argTypes = new_vector();
+				var deconstructor = stmt.unary.computedType.lookup_method_with_arguments(&deconstructorName, argTypes);
 
 				if(deconstructor != null && !deconstructor.funktion.dced) {
 					deconstructor.funktion.dced = true;
@@ -243,7 +246,8 @@ function Parser.dce_statement(stmt: Node*) {
 				var deconstructorName: Name;
 				this.bind_name(&deconstructorName, deconstructorTok);
 
-				var deconstructor = stmt.unary.computedType.lookup_method(&deconstructorName);
+				var argTypes = new_vector();
+				var deconstructor = stmt.unary.computedType.lookup_method_with_arguments(&deconstructorName, argTypes);
 
 				if(deconstructor != null && !deconstructor.funktion.dced) {
 					deconstructor.funktion.dced = true;

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -16,7 +16,7 @@ function Parser.dce_expression(expr: Node*) {
 
 	when(expr.type) {
 		NodeType::CALL -> {
-			var funktion = this.lookup_variable(&expr.funktion.name);
+			var funktion = this.lookup_function_with_arguments(&expr.funktion.name, expr.funktion.argTypes);
 			assert(funktion.type == NodeType::FUNCTION, "Typecheck must verify function call type");
 
 			for(var i = 0; i < expr.funktion.arguments.size; ++i) {
@@ -271,19 +271,27 @@ function Parser.dce() {
 	var mainName: Name;
 	this.bind_name(&mainName, mainTok);
 
-	var main = this.lookup_variable(&mainName);
-	main.funktion.dced = true;
+	var mainList = this.lookup_function(&mainName);
 
-	if(main == null) {
+	if(mainList == null) {
 		eputsln("A 'main' function must be defined for a zephyr program");
 		exit(1);
 	}
 
-	if(main.type != NodeType::FUNCTION) {
-		main.print_position();
-		eputsln("'main' must be a function");
+	if(mainList.size != 1) {
+		eputsln("A program may only define 1 'main' method");
+		eputsln("'main' defined at:");
+		for(var i = 0; i < mainList.size; ++i) {
+			var func: Node* = mainList.at(i);
+			func.funktion.name.print_position();
+			eputln();
+		}
 		exit(1);
 	}
+
+	var main: Node* = mainList.at(0);
+
+	main.funktion.dced = true;
 
 	this.dce_function(main);
 

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -1,4 +1,5 @@
 import "std/core.zpr";
+import "std/map.zpr";
 import "src/types.zpr";
 import "src/lexer.zpr";
 import "src/ast.zpr";
@@ -12,7 +13,7 @@ struct Parser {
 	currentFunction: Node*;
 	currentBlock: Node*;
 
-	functions: Vector*;
+	functions: std::map::HashMap*;
 
 	globalVars: Vector*;
 
@@ -36,7 +37,7 @@ struct Parser {
 function new_parser(lexer: Lexer*): Parser* {
 	var parser: Parser* = malloc(sizeof(Parser));
 	parser.lexer = lexer;
-	parser.functions = new_vector();
+	parser.functions = new std::map::HashMap();
 	parser.globalVars = new_vector();
 	parser.strings = new_vector();
 	parser.floats = new_vector();
@@ -79,6 +80,30 @@ function Parser.bind_namespace(name: Name*) {
 
 function bind_to_namespace(name: Name*, namespaceName: Namespace*) {
 	name.namespaceName = namespaceName;
+}
+
+function Parser.add_function(funktion: Node*) {
+	var nameStr = funktion.funktion.name.to_string();
+
+	var found = false;
+	var list = this.functions.get(nameStr, &found) as Vector*;
+
+	if(found) {
+		list.push(funktion);
+	}
+	else {
+		list = new_vector();
+		list.push(funktion);
+		this.functions.set(nameStr, list);
+	}
+}
+
+function Parser.get_function(name: Name*, found: bool*): Vector* {
+	var nameStr = name.to_string();
+
+	var list = this.functions.get(nameStr, found) as Vector*;
+
+	return list;
 }
 
 function allow_expr_stmt(expr: Node*): int {
@@ -1279,9 +1304,9 @@ function Parser.parse_function(): Node* {
 	if(!funktion.funktion.isMethod) {
 		this.namespace_name(&funktion.funktion.name, name);
 
-		var redef = this.lookup_function(&funktion.funktion.name);
-		if(redef != null) {
-			this.error("Redeclaration of function");
+		var funcList = this.lookup_function(&funktion.funktion.name);
+		if(funcList != null) {
+			var func: Node* = funcList.at(0);
 		}
 	} else {
 		this.bind_name(&funktion.funktion.name, name);
@@ -1327,7 +1352,7 @@ function Parser.parse_function(): Node* {
 
 	this.currentFunction = funktion;
 
-	this.functions.push(funktion);
+	this.add_function(funktion);
 
 	var body = this.parse_block();
 
@@ -1698,7 +1723,7 @@ function Parser.parse_program(): Node* {
 	var builtins = parser_builtin_functions();
 
 	for(var i = 0; i < builtins.size; ++i) {
-		this.functions.push(builtins.at(i));
+		this.add_function(builtins.at(i));
 	}
 
 	this.lexerStack.push(this.lexer);

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -1303,11 +1303,8 @@ function Parser.parse_function(): Node* {
 
 	if(!funktion.funktion.isMethod) {
 		this.namespace_name(&funktion.funktion.name, name);
-
-		var funcList = this.lookup_function(&funktion.funktion.name);
-		if(funcList != null) {
-			var func: Node* = funcList.at(0);
-		}
+		
+		this.add_function(funktion);
 	} else {
 		this.bind_name(&funktion.funktion.name, name);
 
@@ -1351,8 +1348,6 @@ function Parser.parse_function(): Node* {
 	funktion.funktion.returnType = type;
 
 	this.currentFunction = funktion;
-
-	this.add_function(funktion);
 
 	var body = this.parse_block();
 

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -103,6 +103,8 @@ function Parser.get_function(name: Name*, found: bool*): Vector* {
 
 	var list = this.functions.get(nameStr, found) as Vector*;
 
+	delete[] nameStr;
+
 	return list;
 }
 
@@ -1313,7 +1315,7 @@ function Parser.parse_function(): Node* {
 			this.error("Redeclaration of method");
 		}
 
-		funktion.funktion.parentType.methods.push(funktion);
+		funktion.funktion.parentType.add_method(funktion);
 	}
 	
 	this.consume(TokenType::LEFT_PAREN, "Expected '(' after function name");
@@ -1431,7 +1433,7 @@ function Parser.parse_struct_definition(member: int): Node* {
 		this.bind_name(&structType.name, name);
 
 	structType.fields = new_vector();
-	structType.methods = new_vector();
+	structType.methods = new std::map::HashMap;
 
 	do {
 		if(this.match(TokenType::UNION)) {

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -103,8 +103,6 @@ function Parser.get_function(name: Name*, found: bool*): Vector* {
 
 	var list = this.functions.get(nameStr, found) as Vector*;
 
-	delete[] nameStr;
-
 	return list;
 }
 
@@ -1309,11 +1307,6 @@ function Parser.parse_function(): Node* {
 		this.add_function(funktion);
 	} else {
 		this.bind_name(&funktion.funktion.name, name);
-
-		var redef = funktion.funktion.parentType.lookup_method(&funktion.funktion.name);
-		if(redef != null) {
-			this.error("Redeclaration of method");
-		}
 
 		funktion.funktion.parentType.add_method(funktion);
 	}

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -430,13 +430,37 @@ function Type.lookup_field(name: Token*): Node* {
 	return null;
 }
 
-function Type.lookup_method(name: Name*): Node* {
+function Type.lookup_method(name: Name*): Vector* {
 	resolve_type(this);
 
-	for(var i = 0; i < this.methods.size; ++i) {
-		var method: Node* = this.methods.at(i);
+	var found = false;
+	var methodList = this.get_method(name, &found);
 
-		if(method.funktion.name.equals(name)) {
+	return methodList;
+}
+
+function Type.lookup_method_with_arguments(name: Name*, arguments: Vector*): Node* {
+	var list = this.lookup_method(name);
+	if(list == null) return null;
+
+	for(var i = 0; i < list.size; ++i) {
+		var method: Node* = list.at(i);
+
+		if(method.funktion.arguments.size - 1 != arguments.size) continue;
+
+		var match = true;
+
+		for(var arg = 1; arg < method.funktion.arguments.size; ++arg) {
+			var defArg: Node* = method.funktion.arguments.at(arg);
+			var givenType: Type* = arguments.at(arg - 1);
+
+			if(!givenType.assignable(defArg.variable.type)) {
+				match = false;
+				break;
+			}
+		}
+
+		if(match) {
 			return method;
 		}
 	}
@@ -691,25 +715,13 @@ function Parser.type_check_method_call(expr: Node*) {
 	resolve_type(parentType);
 
 	var name = expr.funktion.name;
-	var funktion: Node*;
 
 	if(parentType.type == DataType::STRUCT && parentType.indirection == 0) {
-		funktion = parentType.lookup_method(&name);
-		if(funktion == null) {
-			name.print_position();
-			eputs("Type "); eputs(type_to_string(parentType)); eputs(" has no method '"); name.eput(); eputsln("'");
-			exit(1);
-		}
+		// Valid case
 	}
 	else if(parentType.type == DataType::STRUCT && parentType.indirection == 1 && !parentType.isArray) {
 		var copy = copy_type(parentType);
 		copy.indirection = copy.indirection - 1;
-		funktion = copy.lookup_method(&name);
-		if(funktion == null) {
-			name.print_position();
-			eputs("Type "); eputs(type_to_string(copy)); eputs(" has no method '"); name.eput(); eputsln("'");
-			exit(1);
-		}
 		parentType = copy;
 	}
 	else {
@@ -720,38 +732,35 @@ function Parser.type_check_method_call(expr: Node*) {
 
 	expr.funktion.parentType = parentType;
 
-	if(funktion == null) {
-		expr.print_position();
-		eputs("Unknown method '"); name.eput(); eputs("'' of type "); eputs(type_to_string(parentType)); eputln();
-		exit(1);
-	}
-
-	if(funktion.type != NodeType::FUNCTION) {
-		expr.print_position();
-		eputsln("Can only call functions");
-		exit(1);
-	}
-
-	if(funktion.funktion.arguments.size - 1 != expr.funktion.arguments.size) {
-		expr.print_position();
-		eputs("Call expected "); eputd(funktion.funktion.arguments.size - 1); eputs(" arguments but got "); eputd(expr.funktion.arguments.size); eputln();
-		exit(1);
-	}
-
-	for(var i = 1; i < funktion.funktion.arguments.size; ++i) {
-		var arg: Node* = expr.funktion.arguments.at(i - 1);
+	var argTypes = new_vector();
+	for(var i = 0; i < expr.funktion.arguments.size; ++i) {
+		var arg: Node* = expr.funktion.arguments.at(i);
 		this.type_check_expr(arg);
 
 		var argType: Type* = typeStack.pop();
-		var paramType = (funktion.funktion.arguments.at(i) as Node*).variable.type;
+		argTypes.push(argType);
+	}
 
-		if(!argType.assignable(paramType)) {
-			expr.print_position();
-			eputs("Function argument "); eputd(i - 1); eputs(" expected type "); eputs(type_to_string(paramType)); eputs(" but got ");
-			eputs(type_to_string(argType)); eputln();
-			exit(1);
+	var funktion = parentType.lookup_method_with_arguments(&name, argTypes);
+
+	if(funktion == null) {
+		expr.print_position();
+		eputs("Failed to resolve method '"); expr.funktion.name.eput(); eputs("' of type "); eputsln(type_to_string(parentType));
+		eputs("Given argument types: "); eput_argument_types(argTypes); eputln();
+		exit(1);
+	}
+
+	var paramTypes = funktion.funktion.argTypes;
+	if(paramTypes == null) {
+		paramTypes = new_vector();
+		for(var i = 1; i < funktion.funktion.arguments.size; ++i) {
+			var type: Type* = (funktion.funktion.arguments.at(i) as Node*).variable.type;
+			resolve_type(type);
+			paramTypes.push(type);
 		}
 	}
+
+	expr.funktion.argTypes = paramTypes;
 
 	expr.computedType = funktion.funktion.returnType;
 	typeStack.push(funktion.funktion.returnType);
@@ -957,29 +966,35 @@ function Parser.type_check_new(expr: Node*) {
 			expr.constructor.arguments = null;
 		}
 		else {
-			// Type check as if it were a method call
-			if(constructor.funktion.arguments.size - 1 != expr.constructor.arguments.size) {
-				expr.print_position();
-				eputs("Call expected "); eputd(constructor.funktion.arguments.size - 1); eputs(" arguments but got "); eputd(expr.constructor.arguments.size); eputln();
-				exit(1);
-			}
-
-			for(var i = 1; i < constructor.funktion.arguments.size; ++i) {
-				var arg: Node* = expr.constructor.arguments.at(i - 1);
+			var argTypes = new_vector();
+			for(var i = 0; i < expr.constructor.arguments.size; ++i) {
+				var arg: Node* = expr.constructor.arguments.at(i);
 				this.type_check_expr(arg);
 
 				var argType: Type* = typeStack.pop();
-				
-				var param: Node* = constructor.funktion.arguments.at(i);
-				var paramType = param.variable.type;
+				argTypes.push(argType);
+			}
 
-				if(!argType.assignable(paramType)) {
-					expr.print_position();
-					eputs("Function argument "); eputd(i + 1); eputs(" expected type "); eputs(type_to_string(paramType)); eputs(" but got ");
-					eputs(type_to_string(argType)); eputln();
-					exit(1);
+			var constructor = expr.constructor.type.lookup_method_with_arguments(&constructorName, argTypes);
+
+			if(constructor == null) {
+				expr.print_position();
+				eputs("Failed to resolve constructor"); eputs(" of type "); eputsln(type_to_string(expr.constructor.type));
+				eputs("Given argument types: "); eput_argument_types(argTypes); eputln();
+				exit(1);
+			}
+
+			var paramTypes = constructor.funktion.argTypes;
+			if(paramTypes == null) {
+				paramTypes = new_vector();
+				for(var i = 1; i < constructor.funktion.arguments.size; ++i) {
+					var type: Type* = (constructor.funktion.arguments.at(i) as Node*).variable.type;
+					resolve_type(type);
+					paramTypes.push(type);
 				}
 			}
+
+			expr.constructor.argTypes = paramTypes;
 			expr.constructor.shouldConstruct = true;
 		}
 	}
@@ -1007,7 +1022,17 @@ function Parser.type_check_new_array(expr: Node*) {
 		var constructor = expr.constructor.type.lookup_method(&constructorName);
 		// Perform default operation if constructor does not exist
 		// (for now, ) creating via an array does not care if a constructor with more arguments is the only option
-		if(constructor != null && constructor.funktion.arguments.size - 1 == 0) {
+		if(constructor == null) {
+			expr.constructor.shouldConstruct = false;
+		}
+		else {
+			var argTypes = new_vector();
+			var constructorMethod = expr.constructor.type.lookup_method_with_arguments(&constructorName, argTypes);
+
+			if(constructorMethod == null) {
+				eputs("Failed to resolve default constructor"); eputs(" of type "); eputsln(type_to_string(expr.constructor.type));
+				exit(1);
+			}
 			expr.constructor.shouldConstruct = true;
 		}
 	}
@@ -1237,29 +1262,34 @@ function Parser.type_check_define_var(stmt: Node*) {
 			stmt.variable.arguments = null;
 		}
 		else {
-			// Type check as if it were a method call
-			if(constructor.funktion.arguments.size - 1 != stmt.variable.arguments.size) {
-				stmt.print_position();
-				eputs("Call expected "); eputd(constructor.funktion.arguments.size - 1); eputs(" arguments but got "); eputd(stmt.variable.arguments.size); eputln();
-				exit(1);
-			}
-
-			for(var i = 1; i < constructor.funktion.arguments.size; ++i) {
-				var arg: Node* = stmt.variable.arguments.at(i - 1);
+			var argTypes = new_vector();
+			for(var i = 0; i < stmt.variable.arguments.size; ++i) {
+				var arg: Node* = stmt.variable.arguments.at(i);
 				this.type_check_expr(arg);
 
 				var argType: Type* = typeStack.pop();
-				
-				var param: Node* = constructor.funktion.arguments.at(i);
-				var paramType = param.variable.type;
+				argTypes.push(argType);
+			}
 
-				if(!argType.assignable(paramType)) {
-					stmt.print_position();
-					eputs("Function argument "); eputd(i + 1); eputs(" expected type "); eputs(type_to_string(paramType)); eputs(" but got ");
-					eputs(type_to_string(argType)); eputln();
-					exit(1);
+			var constructor = stmt.variable.type.lookup_method_with_arguments(&constructorName, argTypes);
+
+			if(constructor == null) {
+				stmt.print_position();
+				eputs("Failed to resolve constructor"); eputs(" of type "); eputsln(type_to_string(stmt.variable.type));
+				eputs("Given argument types: "); eput_argument_types(argTypes); eputln();
+				exit(1);
+			}
+
+			var paramTypes = constructor.funktion.argTypes;
+			if(paramTypes == null) {
+				paramTypes = new_vector();
+				for(var i = 1; i < constructor.funktion.arguments.size; ++i) {
+					var type: Type* = (constructor.funktion.arguments.at(i) as Node*).variable.type;
+					resolve_type(type);
+					paramTypes.push(type);
 				}
 			}
+			stmt.variable.argTypes = paramTypes;
 		}
 	}
 
@@ -1269,16 +1299,18 @@ function Parser.type_check_define_var(stmt: Node*) {
 		var constructorName: Name;
 		this.bind_name(&constructorName, constructorTok);
 
-		var constructor = stmt.variable.type.lookup_method(&constructorName);
+		var constructors = stmt.variable.type.lookup_method(&constructorName);
 
-		if(constructor != null) {
-			if(constructor.funktion.arguments.size - 1 > 0) {
+		if(constructors != null) {
+			stmt.variable.arguments = new_vector();
+			
+			var argTypes = new_vector();
+			var constructor = stmt.variable.type.lookup_method_with_arguments(&constructorName, argTypes);
+
+			if(constructor == null) {
 				stmt.print_position();
-				eputs("Constructor expected "); eputd(constructor.funktion.arguments.size - 1); eputsln(" arguments but got 0");
+				eputs("Could not resolve default constructor of type "); eputsln(type_to_string(stmt.variable.type));
 				exit(1);
-			}
-			else {
-				stmt.variable.arguments = new_vector();
 			}
 		}
 	}
@@ -1471,14 +1503,17 @@ function Parser.type_check_delete_statement(stmt: Node*) {
 		var deconstructorName: Name;
 		this.bind_name(&deconstructorName, deconstructorTok);
 
-		var deconstructor = targetType.lookup_method(&deconstructorName);
+		var argTypes = new_vector();
+		var deconstructors = targetType.lookup_method(&deconstructorName);
 
-		if(deconstructor != null) {
+		if(deconstructors != null) {
 			stmt.deconstructor.shouldDeconstruct = true;
-			if(deconstructor.funktion.arguments.size - 1 != 0) {
+
+			var argTypes = new_vector();
+			var deconstructor = targetType.lookup_method_with_arguments(&deconstructorName, argTypes);
+			if(deconstructor == null) {
 				stmt.print_position();
-				eputs("The deconstructor of type "); eputs(type_to_string(targetType)); eputs(" must have 0 arguments (has "); 
-				eputu(deconstructor.funktion.arguments.size - 1); eputsln(")");
+				eputs("The deconstructor of type "); eputs(type_to_string(targetType)); eputsln(" must have 0 arguments");
 				exit(1);
 			}
 		}
@@ -1538,13 +1573,15 @@ function Parser.type_check_delete_array_statement(stmt: Node*) {
 		var deconstructorName: Name;
 		this.bind_name(&deconstructorName, deconstructorTok);
 
-		var deconstructor = elementType.lookup_method(&deconstructorName);
+		var deconstructors = elementType.lookup_method(&deconstructorName);
 
-		if(deconstructor != null) {
-			if(deconstructor.funktion.arguments.size - 1 != 0) {
+		if(deconstructors != null) {
+			var argTypes = new_vector();
+			var deconstructor = elementType.lookup_method_with_arguments(&deconstructorName, argTypes);
+
+			if(deconstructor == null) {
 				stmt.print_position();
-				eputs("The deconstructor of type "); eputs(type_to_string(elementType)); eputs(" must have 0 arguments (has "); 
-				eputu(deconstructor.funktion.arguments.size); eputsln(")");
+				eputs("The deconstructor of type "); eputs(type_to_string(elementType)); eputsln(" must have 0 arguments"); 
 				exit(1);
 			}
 			stmt.deconstructor.shouldDeconstruct = true;
@@ -1675,16 +1712,18 @@ function Parser.type_check_block(block: Node*) {
 		var deconstructorName: Name;
 		this.bind_name(&deconstructorName, deconstructorTok);
 
-		var deconstructor = stmt.variable.type.lookup_method(&deconstructorName);
+		var deconstructors = stmt.variable.type.lookup_method(&deconstructorName);
 
-		if(deconstructor != null) {
-			stmt.deconstructor.shouldDeconstruct = true;
-			if(deconstructor.funktion.arguments.size - 1 != 0) {
+		if(deconstructors != null) {
+			var argTypes = new_vector();
+			var deconstructor = stmt.variable.type.lookup_method_with_arguments(&deconstructorName, argTypes);
+
+			if(deconstructor == null) {
 				stmt.print_position();
-				eputs("The deconstructor of type "); eputs(type_to_string(stmt.variable.type)); eputs(" must have 0 arguments (has "); 
-				eputu(deconstructor.funktion.arguments.size - 1); eputsln(")");
+				eputs("The deconstructor of type "); eputs(type_to_string(stmt.variable.type)); eputsln(" must have 0 arguments"); 
 				exit(1);
 			}
+			stmt.deconstructor.shouldDeconstruct = true;
 		}
 	}
 

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -256,38 +256,92 @@ function Parser.lookup_variable(name: Name*): Node* {
 	var global = this.lookup_global_variable(name);
 	if(global != null) return global;
 
-	var funktion = this.lookup_function(name);
-	if(funktion != null) return funktion;
-
 	return null;
 }
 
-function Parser.lookup_function(name: Name*): Node* {
+function Parser.lookup_function(name: Name*): Vector* {
 	if(name.namespaceName == null) {
 		for(var ni = namespaces.size - 1; ni >= 0; --ni) {
 			var nameSpace: Namespace* = namespaces.at(ni);
 
-			for(var i = 0; i < this.functions.size; ++i) {
-				var func: Node* = this.functions.at(i);
+			bind_to_namespace(name, nameSpace);
 
-				bind_to_namespace(name, nameSpace);
+			var found = false;
+			var funcList = this.get_function(name, &found);
 
-				if(func.funktion.name.equals(name) && !func.funktion.isMethod) {
-					return func;
-				}
+			if(found) {
+				return funcList;
 			}
 		}
 		name.namespaceName = null;
 	}
 
-	for(var i = 0; i < this.functions.size; ++i) {
-		var func: Node* = this.functions.at(i);
-		if(func.funktion.name.equals(name) && !func.funktion.isMethod) {
+	var found = false;
+	var funcList = this.get_function(name, &found);
+
+	return funcList;
+}
+
+function Parser.lookup_function_with_arguments(name: Name*, arguments: Vector*): Node* {
+	var list = this.lookup_function(name);
+	if(list == null) return null;
+
+	for(var i = 0; i < list.size; ++i) {
+		var func: Node* = list.at(i);
+
+		if(func.funktion.isMethod) continue;
+		if(func.funktion.arguments.size != arguments.size) continue;
+
+		var match = true;
+
+		for(var arg = 0; arg < arguments.size; ++arg) {
+			var defArg: Node* = func.funktion.arguments.at(arg);
+			var givenType: Type* = arguments.at(arg);
+
+			if(!givenType.assignable(defArg.variable.type)) {
+				match = false;
+				break;
+			}
+		}
+
+		if(match) {
 			return func;
 		}
 	}
 
 	return null;
+}
+
+function Parser.count_function_with_arguments(name: Name*, arguments: Vector*): int {
+	var list = this.lookup_function(name);
+	if(list == null) return 0;
+
+	var count = 0;
+	
+	for(var i = 0; i < list.size; ++i) {
+		var func: Node* = list.at(i);
+
+		if(func.funktion.isMethod) continue;
+		if(func.funktion.arguments.size != arguments.size) continue;
+
+		var match = true;
+
+		for(var arg = 0; arg < arguments.size; ++arg) {
+			var defArg: Node* = func.funktion.arguments.at(arg);
+			var givenType: Type* = arguments.at(arg);
+
+			if(!givenType.assignable(defArg.variable.type)) {
+				match = false;
+				break;
+			}
+		}
+
+		if(match) {
+			++count;
+		}
+	}
+
+	return count;
 }
 
 function Parser.lookup_constant(name: Name*): Node* {
@@ -390,6 +444,16 @@ function Type.lookup_method(name: Name*): Node* {
 	}
 
 	return null;
+}
+
+function eput_argument_types(argTypes: Vector*) {
+	eputs("(");
+	for(var i = 0; i < argTypes.size; ++i) {
+		var arg: Type* = argTypes.at(i);
+		eputs(uq_type_to_string(arg));
+		if(i != argTypes.size - 1) eputs(", ");
+	}
+	eputs(")");
 }
 
 function assignment_op_to_node_type(op: int): int {
@@ -581,45 +645,45 @@ function Parser.type_check_access_var(expr: Node*) {
 }
 
 function Parser.type_check_call(expr: Node*) {
-	var funktion = this.lookup_variable(&expr.funktion.name);
+	var funcList = this.lookup_function(&expr.funktion.name);
 
-	if(funktion == null) {
+	if(funcList == null) {
 		expr.print_position();
-		eputs("Unknown variable '"); expr.funktion.name.eput(); eputsln("' in current scope");
+		eputs("Unknown function '"); expr.funktion.name.eput(); eputsln("' in current scope");
 		exit(1);
 	}
 
-	if(funktion.type != NodeType::FUNCTION) {
-		expr.print_position();
-		eputsln("Can only call functions");
-		exit(1);
-	}
-
-	if(funktion.funktion.arguments.size != expr.funktion.arguments.size) {
-		expr.print_position();
-		eputs("Call expected "); eputd(funktion.funktion.arguments.size); eputs(" arguments but got "); eputd(expr.funktion.arguments.size); eputln();
-		exit(1);
-	}
-
-	for(var i = 0; i < funktion.funktion.arguments.size; ++i) {
+	var argTypes = new_vector();
+	for(var i = 0; i < expr.funktion.arguments.size; ++i) {
 		var arg: Node* = expr.funktion.arguments.at(i);
 		this.type_check_expr(arg);
 
 		var argType: Type* = typeStack.pop();
-		
-		var param: Node* = funktion.funktion.arguments.at(i);
-		var paramType = param.variable.type;
+		argTypes.push(argType);
+	}
 
-		if(!argType.assignable(paramType)) {
-			expr.print_position();
-			eputs("Function argument "); eputd(i + 1); eputs(" expected type "); eputs(type_to_string(paramType)); eputs(" but got ");
-			eputs(type_to_string(argType)); eputln();
-			exit(1);
+	var func = this.lookup_function_with_arguments(&expr.funktion.name, argTypes);
+
+	if(func == null) {
+		expr.print_position();
+		eputs("Failed to resolve function '"); expr.funktion.name.eput(); eputsln("'");
+		eputs("Given argument types: "); eput_argument_types(argTypes); eputln();
+		exit(1);
+	}
+
+	var paramTypes = func.funktion.argTypes;
+	if(paramTypes == null) {
+		paramTypes = new_vector();
+		for(var i = 0; i < func.funktion.arguments.size; ++i) {
+			var type: Type* = (func.funktion.arguments.at(i) as Node*).variable.type;
+			resolve_type(type);
+			paramTypes.push(type);
 		}
 	}
 
-	expr.computedType = funktion.funktion.returnType;
-	typeStack.push(funktion.funktion.returnType);
+	expr.funktion.argTypes = paramTypes;
+	expr.computedType = func.funktion.returnType;
+	typeStack.push(func.funktion.returnType);
 }
 
 function Parser.type_check_method_call(expr: Node*) {
@@ -855,13 +919,13 @@ function Parser.resolve_malloc_function(): Node* {
 	var mallocName: Name;
 	this.bind_name(&mallocName, mallocTok);
 
-	var mallocFunc = this.lookup_function(&mallocName);
+	var arguments = new_vector();
+	arguments.push(UINT_TYPE);
+
+	var mallocFunc = this.lookup_function_with_arguments(&mallocName, arguments);
 
 	if(mallocFunc == null) return null;
 	if(mallocFunc.funktion.name.namespaceName != null) return null;
-	if(mallocFunc.funktion.arguments.size != 1) return null;
-	var arg: Node* = mallocFunc.funktion.arguments.at(0);
-	if(arg.variable.type.type != DataType::UINT || arg.variable.type.indirection != 0) return null;
 	if(mallocFunc.funktion.returnType.type != DataType::ANY || mallocFunc.funktion.returnType.indirection != 1) return null;
 
 	return mallocFunc;
@@ -1375,13 +1439,13 @@ function Parser.resolve_free_function(): Node* {
 	var freeName: Name;
 	this.bind_name(&freeName, freeTok);
 
-	var freeFunc = this.lookup_function(&freeName);
+	var arguments = new_vector();
+	arguments.push(ANYP_TYPE);
+
+	var freeFunc = this.lookup_function_with_arguments(&freeName, arguments);
 
 	if(freeFunc == null) return null;
 	if(freeFunc.funktion.name.namespaceName != null) return null;
-	if(freeFunc.funktion.arguments.size != 1) return null;
-	var arg: Node* = freeFunc.funktion.arguments.at(0);
-	if(arg.variable.type.type != DataType::ANY || arg.variable.type.indirection != 1) return null;
 	if(freeFunc.funktion.returnType.type != DataType::VOID) return null;
 
 	return freeFunc;
@@ -1438,15 +1502,14 @@ function Parser.resolve_get_array_length_function(): Node* {
 
 	bind_to_namespace(&funcName, nameSpace);
 
-	var func = this.lookup_function(&funcName);
+	var arguments = new_vector();
+	arguments.push(ANYP_TYPE);
+	arguments.push(UINT_TYPE);
+
+	var func = this.lookup_function_with_arguments(&funcName, arguments);
 
 	if(func == null) return null;
-	if(func.funktion.arguments.size != 2) return null;
-	var ptrArg: Node* = func.funktion.arguments.at(0);
-	if(ptrArg.variable.type.type != DataType::ANY || ptrArg.variable.type.indirection != 1) return null;
-	var elmSizeArg: Node* = func.funktion.arguments.at(1);
-	if(elmSizeArg.variable.type.type != DataType::UINT || elmSizeArg.variable.type.indirection != 0) return null;
-	if(func.funktion.returnType.type != DataType::UINT) return null;
+	if(func.funktion.returnType.type != DataType::UINT || func.funktion.returnType.indirection != 0) return null;
 
 	return func;
 }
@@ -1632,6 +1695,29 @@ function Parser.type_check_block(block: Node*) {
 
 function Parser.type_check_function(funktion: Node*) {
 	var stackOffset = 0;
+
+	if(!funktion.funktion.isMethod) {
+		var funcList = this.lookup_function(&funktion.funktion.name);
+
+		var paramTypes = new_vector();
+		for(var i = 0; i < funktion.funktion.arguments.size; ++i) {
+			var arg: Node* = funktion.funktion.arguments.at(i);
+
+			paramTypes.push(arg.variable.type);
+		}
+
+		funktion.funktion.argTypes = paramTypes;
+
+		if(funcList.size != 1) {
+			var count = this.count_function_with_arguments(&funktion.funktion.name, paramTypes);
+
+			if(count != 1) {
+				funktion.print_position();
+				eputsln("Redeclaration of function accepting same arguments");
+				exit(1);
+			}
+		}
+	}
 
 	for(var i = 0; i < funktion.funktion.arguments.size; ++i) {
 		var arg: Node* = funktion.funktion.arguments.at(i);

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -468,6 +468,37 @@ function Type.lookup_method_with_arguments(name: Name*, arguments: Vector*): Nod
 	return null;
 }
 
+function Type.count_method_with_arguments(name: Name*, arguments: Vector*): int {
+	var list = this.lookup_method(name);
+	if(list == null) return 0;
+
+	var count = 0;
+
+	for(var i = 0; i < list.size; ++i) {
+		var method: Node* = list.at(i);
+
+		if(method.funktion.arguments.size - 1 != arguments.size) continue;
+
+		var match = true;
+
+		for(var arg = 1; arg < method.funktion.arguments.size; ++arg) {
+			var defArg: Node* = method.funktion.arguments.at(arg);
+			var givenType: Type* = arguments.at(arg - 1);
+
+			if(!givenType.assignable(defArg.variable.type)) {
+				match = false;
+				break;
+			}
+		}
+
+		if(match) {
+			++count;
+		}
+	}
+
+	return count;
+}
+
 function eput_argument_types(argTypes: Vector*) {
 	eputs("(");
 	for(var i = 0; i < argTypes.size; ++i) {
@@ -1312,6 +1343,8 @@ function Parser.type_check_define_var(stmt: Node*) {
 				eputs("Could not resolve default constructor of type "); eputsln(type_to_string(stmt.variable.type));
 				exit(1);
 			}
+
+			stmt.variable.argTypes = argTypes;
 		}
 	}
 
@@ -1751,6 +1784,28 @@ function Parser.type_check_function(funktion: Node*) {
 			if(count != 1) {
 				funktion.print_position();
 				eputsln("Redeclaration of function accepting same arguments");
+				exit(1);
+			}
+		}
+	}
+	else {
+		var methodList = funktion.funktion.parentType.lookup_method(&funktion.funktion.name);
+
+		var paramTypes = new_vector();
+		for(var i = 1; i < funktion.funktion.arguments.size; ++i) {
+			var arg: Node* = funktion.funktion.arguments.at(i);
+
+			paramTypes.push(arg.variable.type);
+		}
+
+		funktion.funktion.argTypes = paramTypes;
+
+		if(methodList.size != 1) {
+			var count = funktion.funktion.parentType.count_method_with_arguments(&funktion.funktion.name, paramTypes);
+
+			if(count != 1) {
+				funktion.print_position();
+				eputsln("Redeclaration of method accepting same arguments");
 				exit(1);
 			}
 		}

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -289,7 +289,6 @@ function Parser.lookup_function_with_arguments(name: Name*, arguments: Vector*):
 	for(var i = 0; i < list.size; ++i) {
 		var func: Node* = list.at(i);
 
-		if(func.funktion.isMethod) continue;
 		if(func.funktion.arguments.size != arguments.size) continue;
 
 		var match = true;
@@ -321,7 +320,6 @@ function Parser.count_function_with_arguments(name: Name*, arguments: Vector*): 
 	for(var i = 0; i < list.size; ++i) {
 		var func: Node* = list.at(i);
 
-		if(func.funktion.isMethod) continue;
 		if(func.funktion.arguments.size != arguments.size) continue;
 
 		var match = true;

--- a/src/types.zpr
+++ b/src/types.zpr
@@ -7,6 +7,7 @@ var STR_TYPE: Type*;
 var F64_TYPE: Type*;
 var VOID_TYPE: Type*;
 var ANY_TYPE: Type*;
+var ANYP_TYPE: Type*;
 
 function new_type(): Type* {
 	var type: Type* = malloc(sizeof(Type));
@@ -46,4 +47,8 @@ function build_types() {
 
 	ANY_TYPE = new_type();
 	ANY_TYPE.type = DataType::ANY;
+
+	ANYP_TYPE = new_type();
+	ANYP_TYPE.type = DataType::ANY;
+	ANYP_TYPE.indirection = 1;
 }

--- a/std/core.zpr
+++ b/std/core.zpr
@@ -245,6 +245,7 @@ namespace std::internal::malloc {
 			// if the list has at least one item, append this block to the end
 			__free_blocks_last.next = header;
 			header.prev = __free_blocks_last;
+			header.next = null;
 			__free_blocks_last = header;
 		}
 

--- a/std/map.zpr
+++ b/std/map.zpr
@@ -84,7 +84,7 @@ namespace std::map {
 
 		var item = this.find_item(key, hash, this.items, this.capacity);
 
-		if(item == null) {
+		if(item.key == null) {
 			if(found != null) *found = false;
 			return 0;
 		}

--- a/std/map.zpr
+++ b/std/map.zpr
@@ -1,0 +1,107 @@
+import "std/core.zpr";
+
+namespace std::map {
+	struct HashItem {
+		key: i8*;
+		value: any;
+	}
+
+	struct HashMap {
+		items: HashItem*;
+		capacity: uint;
+		count: uint;
+	}
+
+	function HashMap.constructor() {
+		this.count = 0;
+		this.capacity = 8;
+		this.items = new HashItem[this.capacity];
+		memset(this.items, 0, this.capacity * sizeof(HashItem));
+	}
+
+	function HashMap.deconstructor() {
+		delete[] this.items;
+	}
+
+	function HashMap.adjustCapacity() {
+		var newCapacity = this.capacity * 2;
+
+		var items = new HashItem[newCapacity];
+		memset(items, 0, newCapacity * sizeof(HashItem));
+
+		this.count = 0;
+		for(var i = 0; i < this.capacity; ++i) {
+			var item = &this.items[i];
+			if(item.key == null) continue;
+
+			var hash = hash_string(item.key);
+			var dest = this.find_item(item.key, hash, items, newCapacity);
+			dest.key = item.key;
+			dest.value = item.value;
+			++this.count;
+		}
+
+		delete[] this.items;
+		this.items = items;
+		this.capacity = newCapacity;
+	}
+
+	function HashMap.find_item(key: i8*, hash: uint, items: HashItem*, capacity: uint): HashItem* {
+		var idx = hash & (capacity - 1);
+
+		for(;;) {
+			var item = &items[idx];
+
+			if(item.key == null || streq(item.key, key)) {
+				return item;
+			}
+
+			idx = (idx + 1) & (capacity - 1);
+		}
+
+		return null;
+	}
+
+	function HashMap.set(key: i8*, value: any) {
+		var hash = hash_string(key);
+
+		if(this.count + 1 > this.capacity * 0.75) {
+			this.adjustCapacity();
+		}
+
+		var item = this.find_item(key, hash, this.items, this.capacity);
+
+		if(item.key == null) {
+			++this.count;
+		}
+
+		item.key = key;
+		item.value = value;
+	}
+
+	function HashMap.get(key: i8*, found: bool*): any {
+		var hash = hash_string(key);
+
+		var item = this.find_item(key, hash, this.items, this.capacity);
+
+		if(item == null) {
+			if(found != null) *found = false;
+			return 0;
+		}
+
+		if(found != null) *found = true;
+		return item.value;
+	}
+
+	function hash_string(str: i8*): uint {
+		var hash = 5381u;
+		var c: i8;
+
+		while(c = *str) {
+			hash = ((hash << 5) + hash) + c;
+			str = (str as uint + 1) as i8*;
+		}
+
+		return hash;
+	}
+}

--- a/std/map.zpr
+++ b/std/map.zpr
@@ -19,6 +19,13 @@ namespace std::map {
 		memset(this.items, 0, this.capacity * sizeof(HashItem));
 	}
 
+	function HashMap.constructor(initialCapacity: uint) {
+		this.count = 0;
+		this.capacity = initialCapacity;
+		this.items = new HashItem[this.capacity];
+		memset(this.items, 0, this.capacity * sizeof(HashItem));
+	}
+
 	function HashMap.deconstructor() {
 		delete[] this.items;
 	}

--- a/tests/core.sh
+++ b/tests/core.sh
@@ -2323,3 +2323,214 @@ function main(): int {
 "
 
 echo " Done"
+
+echo -n "Function Overloading: "
+
+assert_stdout "15
+6.2" "
+import \"std/io.zpr\";
+
+function add(a: int, b: int): int {
+	return a + b;
+}
+
+function add(a: f64, b: f64): f64 {
+	return a + b;
+}
+
+function main(): int {
+	var i = add(5, 10);
+	var f = add(2.5, 3.7);
+
+	putd(i); putln();
+	putft(f); putln();
+	
+	return 0;
+}
+"
+
+assert_stdout "(30, 16)" "
+import \"std/io.zpr\";
+
+struct Vector2i {
+	x: int;
+	y: int;
+}
+
+function Vector2i.constructor(x: int, y: int) {
+	this.x = x;
+	this.y = y;
+}
+
+function Vector2i.mul(scalar: int) {
+	this.x *= scalar;
+	this.y *= scalar;
+}
+
+function Vector2i.mul(vec: Vector2i*) {
+	this.x *= vec.x;
+	this.y *= vec.y;
+}
+
+function Vector2i.put() {
+	puts(\"(\"); putd(this.x); puts(\", \"); putd(this.y); puts(\")\");
+}
+
+function main(): int {
+	var vec1: Vector2i(5, 2);
+	vec1.mul(2);
+
+	var vec2: Vector2i(3, 4);
+	vec1.mul(&vec2);
+
+	vec1.put(); putln();
+
+	return 0;
+}
+"
+
+assert_compilation_error "
+import \"std/io.zpr\";
+
+function add(a: int, b: int): int {
+	return a + b;
+}
+
+function add(a: int, b: int): f64 {
+	return a + b;
+}
+
+function main(): int {
+	return 0;
+}
+"
+
+assert_compilation_error "
+import \"std/io.zpr\";
+
+struct Vector2i {
+	x: int;
+	y: int;
+}
+
+function Vector2i.mul(scalar: int): int {
+	this.x *= scalar;
+	this.y *= scalar;
+	return this.x * this.y;
+}
+
+function Vector2i.mul(scalar: int) {
+	this.x *= scalar;
+	this.y *= scalar;
+}
+
+function main(): int {
+	return 0;
+}
+"
+
+assert_stdout "Hi, I'm Bob!
+Hi, I'm Poppy!" "
+import \"std/io.zpr\";
+
+struct Person {
+	name: i8*;
+}
+
+function Person.constructor() {
+	this.name = \"Bob\";
+}
+
+function Person.constructor(name: i8*) {
+	this.name = name;
+}
+
+function Person.say_hi() {
+	puts(\"Hi, I'm \"); puts(this.name); putsln(\"!\");
+}
+
+function main(): int {
+	var person: Person;
+	person.say_hi();
+
+	var poppy: Person(\"Poppy\");
+	poppy.say_hi();
+	
+	return 0;
+}
+"
+
+assert_compilation_error "
+import \"std/io.zpr\";
+
+struct Person {
+	name: i8*;
+}
+
+function Person.constructor(name: i8*) {
+	this.name = name;
+}
+
+function Person.say_hi() {
+	puts(\"Hi, I'm \"); puts(this.name); putsln(\"!\");
+}
+
+function main(): int {
+	var person: Person;
+	person.say_hi();
+
+	return 0;
+}
+"
+
+assert_compilation_error "
+import \"std/io.zpr\";
+
+struct Person {
+	name: i8*;
+}
+
+function Person.deconstructor(name: i8*) {
+}
+
+function Person.say_hi() {
+	puts(\"Hi, I'm \"); puts(this.name); putsln(\"!\");
+}
+
+function main(): int {
+	var person: Person;
+	person.say_hi();
+
+	return 0;
+}
+"
+
+assert_stdout "Hi, I'm Alice!" "
+import \"std/io.zpr\";
+
+struct Person {
+	name: i8*;
+}
+
+function Person.constructor(name: i8*) {
+	this.name = name;
+}
+
+function Person.deconstructor() {}
+
+function Person.deconstructor(name: i8*) {
+}
+
+function Person.say_hi() {
+	puts(\"Hi, I'm \"); puts(this.name); putsln(\"!\");
+}
+
+function main(): int {
+	var person: Person(\"Alice\");
+	person.say_hi();
+
+	return 0;
+}
+"
+
+echo " Done"


### PR DESCRIPTION
Allows functions to take the same name if they differ by arguments. For example,
```
import "std/io.zpr";

// (1)
function add(a: int, b: int): int {
	return a + b;
}

// (2)
function add(a: f64, b: f64): f64 {
	return a + b;
}

function main(): int {
	var i = add(5, 10);    // Calls function with integers (1)
	var f = add(2.5, 3.7); // Calls function with floats   (2)

	putd(i); putln();  // 15
	putft(f); putln(); // 6.2
	
	return 0;
}
```
Overloading is also permitted with struct-bound methods, and constructors. Overloaded constructors are respected by `new` as well as stack-allocated structs.