### PR TITLE
Copy Constructors

### DIFF
--- a/bootstrap/bootstrap_x86_64_linux.yasm
+++ b/bootstrap/bootstrap_x86_64_linux.yasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a046520ff197342caa21a4575939e553b34ec6ada8e66100986abff73cd57cae
-size 852845
+oid sha256:ff9df462b8019f5e1eabecaa5b8edba213ab2d6a1206ce86833bfe754dfd0e9e
+size 886028

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -39,6 +39,7 @@ enum NodeType {
 	FLOAT_TO_INT,
 
 	RELATIVE,
+	OVERLOAD,
 	INT_LITERAL,
 	UINT_LITERAL,
 	CHAR_LITERAL,
@@ -273,6 +274,13 @@ struct Node {
 			value: Node*;
 			variables: Vector*;
 		};
+
+		overload: struct {
+			value: Node*;
+			lhsType: Type*;
+			rhsType: Type*;
+			op: Token*;
+		};
 	};
 }
 
@@ -304,6 +312,11 @@ function Name.eput() {
 
 function Name.put() {
 	this.fput(stdout);
+}
+
+function bind_name(name: Name*, token: Token*) {
+	name.name = token;
+	name.namespaceName = null;
 }
 
 function Name.print_position() {
@@ -574,6 +587,7 @@ function node_type_to_string(type: NodeType): i8* {
 		NodeType::STRING -> return "string";
 		NodeType::CALL -> return "call";
 		NodeType::CALL_METHOD -> return "call method";
+		NodeType::OVERLOAD -> return "overload";
 		NodeType::DEFINE_CONST -> return "define const";
 		NodeType::DEFINE_VAR -> return "define var";
 		NodeType::ACCESS_VAR -> return "access var";

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -211,6 +211,7 @@ struct Node {
 			value: Node*;
 			arguments: Vector*;
 			argTypes: Vector*;
+			copyConstructor: bool;
 
 			stackOffset: int;
 			unionField: int;

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -1058,8 +1058,25 @@ function generate_define_var(stmt: Node*, out: File*) {
 		generate_expr(stmt.variable.value, out);
 
 		if(stmt.variable.type.is_structural()) {
-			out.puts("    lea rcx, [rbp-"); out.putd(stmt.variable.stackOffset); out.putsln("]");
-			generate_copy(stmt.variable.type.fields, 0, out);
+			if(stmt.variable.copyConstructor) {
+				var copyTok = synthetic_token(TokenType::IDENTIFIER, "copy");
+				var copyName: Name;
+				parser.bind_name(&copyName, copyTok);
+
+				var args = new_vector();
+				var typePtr = copy_type(stmt.variable.type);
+				typePtr.indirection = 1;
+				args.push(typePtr);
+
+				out.puts("    lea rdi, [rbp-"); out.putd(stmt.variable.stackOffset); out.putsln("]");
+				out.putsln("    mov rsi, rax");
+				out.puts("    call _M"); out.put_arguments(args);
+				out.put_name(&stmt.variable.type.name); out.puts("_"); out.put_name(&copyName); out.putln();
+			}
+			else {
+				out.puts("    lea rcx, [rbp-"); out.putd(stmt.variable.stackOffset); out.putsln("]");
+				generate_copy(stmt.variable.type.fields, 0, out);
+			}
 		}
 		else if(stmt.variable.type.is_float()) {
 			out.puts("    movsd [rbp-"); out.putd(stmt.variable.stackOffset); out.putsln("], xmm0");

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -1476,6 +1476,16 @@ function Parser.generate_program(ast: Node*, out: File*) {
 				out.puts("], "); out.putsln(type.rax_subregister());
 			}
 		}
+
+		if(variable.variable.arguments != null) {
+			var constructorTok = synthetic_token(TokenType::IDENTIFIER, "constructor");
+			var constructorName: Name;
+			parser.bind_name(&constructorName, constructorTok);
+
+			out.puts("    lea rax, [_G"); out.put_name(&variable.variable.name); out.putsln("]");
+
+			generate_method_call(null, variable.variable.type, &constructorName, variable.variable.arguments, variable.variable.argTypes, out);
+		}
 	}
 
 	out.putsln("    pop rdi");

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -1468,8 +1468,25 @@ function Parser.generate_program(ast: Node*, out: File*) {
 			generate_expr(variable.variable.value, out);
 
 			if(type.is_structural()) {
-				out.puts("    lea rcx, [_G"); out.put_name(&variable.variable.name); out.putsln("]");
-				generate_copy(type.fields, 0, out);
+				if(variable.variable.copyConstructor) {
+					var copyTok = synthetic_token(TokenType::IDENTIFIER, "copy");
+					var copyName: Name;
+					parser.bind_name(&copyName, copyTok);
+
+					var args = new_vector();
+					var typePtr = copy_type(variable.variable.type);
+					typePtr.indirection = 1;
+					args.push(typePtr);
+
+					out.puts("    lea rdi, [_G"); out.put_name(&variable.variable.name); out.putsln("]");
+					out.putsln("    mov rsi, rax");
+					out.puts("    call _M"); out.put_arguments(args);
+					out.put_name(&variable.variable.type.name); out.puts("_"); out.put_name(&copyName); out.putln();
+				}
+				else {
+					out.puts("    lea rcx, [_G"); out.put_name(&variable.variable.name); out.putsln("]");
+					generate_copy(type.fields, 0, out);
+				}
 			}
 			else {
 				out.puts("    mov "); out.puts(type.qualifier()); out.puts(" [_G"); out.put_name(&variable.variable.name);
@@ -1519,6 +1536,9 @@ function Parser.generate_program(ast: Node*, out: File*) {
 				var subType = copy_type(type);
 				subType.indirection = type.indirection - 1;
 				out.puts(subType.reserve()); out.puts(" "); out.putd(type.arrayLength); out.putln();
+			}
+			else if(type.type == DataType::STRUCT && type.indirection == 0 && type.size() > 8) {
+				out.puts("resb "); out.putd(type.size()); out.putln();
 			}
 			else {
 				out.puts(variable.variable.type.reserve()); out.putsln(" 1");

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -649,6 +649,20 @@ function generate_assign(expr: Node*, out: File*) {
 	if(expr.assignment.op.type != TokenType::EQ) {
 		expr.assignment.rhs.binary.lhs.type = NodeType::RELATIVE;
 	}
+
+	if(expr.assignment.rhs.type == NodeType::OVERLOAD) {
+		generate_expr(expr.assignment.rhs.overload.value, out);
+		out.putsln("    mov rsi, rax");
+		out.putsln("    mov rax, QWORD [rsp]");
+
+		var args = new_vector();
+		args.push(expr.assignment.rhs.overload.rhsType);
+
+		generate_method_call(null, expr.assignment.rhs.overload.lhsType, Typecheck::get_name_from_overload(expr.assignment.rhs.overload.op), null, args, out);
+		out.putsln("    pop rax");
+		return;
+	}
+
 	generate_expr(expr.assignment.rhs, out);
 	out.putsln("    pop rcx");
 
@@ -1400,7 +1414,10 @@ function Parser.generate_string(str: Node*, out: File*) {
 		out.putc('\"');
 	}
 
-	out.putsln(", 0");
+	if(first)
+		out.putsln("0");
+	else
+		out.putsln(", 0");
 }
 
 function Parser.generate_program(ast: Node*, out: File*) {

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -113,6 +113,14 @@ function Parser.dce_expression(expr: Node*) {
 				}
 			}
 		}
+		NodeType::OVERLOAD -> {
+			this.dce_expression(expr.overload.value);
+			var func = Typecheck::get_overload_function(expr.overload.lhsType, expr.overload.rhsType, expr.overload.op);
+			if(!func.funktion.dced) {
+				func.funktion.dced = true;
+				this.dce_function(func);
+			}
+		}
 		NodeType::SIZEOF,
 		NodeType::CHAR_LITERAL, NodeType::INT_LITERAL, NodeType::UINT_LITERAL, NodeType::ACCESS_VAR -> {}
 		else -> {

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -176,14 +176,28 @@ function Parser.dce_statement(stmt: Node*) {
 				this.dce_statement(stmt.vhen.default);
 		}
 		NodeType::DEFINE_VAR -> {
-			if(stmt.variable.value != null)
+			if(stmt.variable.value != null) {
 				this.dce_expression(stmt.variable.value);
+
+				if(stmt.variable.copyConstructor) {
+					var copyTok = synthetic_token(TokenType::IDENTIFIER, "copy");
+					var copyName: Name;
+					this.bind_name(&copyName, copyTok);
+
+					var args = new_vector();
+					var typePtr = copy_type(stmt.variable.type);
+					typePtr.indirection = 1;
+					args.push(typePtr);
+
+					var copy = stmt.variable.type.lookup_method_with_arguments(&copyName, args);
+					this.dce_function(copy);
+				}
+			}
 			if(stmt.variable.arguments != null) {
 				var constructorTok = synthetic_token(TokenType::IDENTIFIER, "constructor");
 				var constructorName: Name;
 				this.bind_name(&constructorName, constructorTok);
 
-				//TODO THIS IS NULL
 				var constructor = stmt.variable.type.lookup_method_with_arguments(&constructorName, stmt.variable.argTypes);
 				if(!constructor.funktion.dced) {
 					constructor.funktion.dced = true;

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -325,8 +325,23 @@ function Parser.dce() {
 	for(var i = 0; i < this.globalVars.size; ++i) {
 		var gvar: Node* = this.globalVars.at(i);
 
-		if(gvar.variable.value != null)
+		if(gvar.variable.value != null) {
 			this.dce_expression(gvar.variable.value);
+
+			if(gvar.variable.copyConstructor) {
+				var copyTok = synthetic_token(TokenType::IDENTIFIER, "copy");
+				var copyName: Name;
+				this.bind_name(&copyName, copyTok);
+
+				var args = new_vector();
+				var typePtr = copy_type(gvar.variable.type);
+				typePtr.indirection = 1;
+				args.push(typePtr);
+
+				var copy = gvar.variable.type.lookup_method_with_arguments(&copyName, args);
+				this.dce_function(copy);
+			}
+		}
 
 		if(gvar.variable.arguments != null) {
 			var constructorTok = synthetic_token(TokenType::IDENTIFIER, "constructor");

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -327,5 +327,21 @@ function Parser.dce() {
 
 		if(gvar.variable.value != null)
 			this.dce_expression(gvar.variable.value);
+
+		if(gvar.variable.arguments != null) {
+			var constructorTok = synthetic_token(TokenType::IDENTIFIER, "constructor");
+			var constructorName: Name;
+			this.bind_name(&constructorName, constructorTok);
+
+			var constructor = gvar.variable.type.lookup_method_with_arguments(&constructorName, gvar.variable.argTypes);
+			if(!constructor.funktion.dced) {
+				constructor.funktion.dced = true;
+				this.dce_function(constructor);
+			}
+
+			for(var i = 0; i < gvar.variable.arguments.size; ++i) {
+				this.dce_expression(gvar.variable.arguments.at(i));
+			}
+		}
 	}
 }

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -499,6 +499,28 @@ function Type.count_method_with_arguments(name: Name*, arguments: Vector*): int 
 	return count;
 }
 
+function get_name_from_overload(op: Token*): Name* {
+	var funcName: i8*;
+	when(op.type) {
+		TokenType::EQ -> funcName = "copy";
+	}
+
+	var nameTok = synthetic_token(TokenType::IDENTIFIER, funcName);
+	var name = new Name;
+	bind_name(name, nameTok);
+	return name;
+}
+
+function get_overload_function(lhs: Type*, rhs: Type*, op: Token*): Node* {
+	var name = get_name_from_overload(op);
+
+	var args = new_vector();
+	args.push(rhs);
+
+	var copy = lhs.lookup_method_with_arguments(name, args);
+	return copy;
+}
+
 function eput_argument_types(argTypes: Vector*) {
 	eputs("(");
 	for(var i = 0; i < argTypes.size; ++i) {
@@ -920,6 +942,32 @@ function Parser.type_check_assign(expr: Node*) {
 		eputs("Cannot assign type "); eputs(type_to_string(rhs)); eputs(" to type "); eputs(type_to_string(lhs));
 		eputln();
 		exit(1);
+	}
+
+	if(expr.assignment.op.type == TokenType::EQ) {
+		// lhs and rhs are the same structure
+		if(lhs.type == DataType::STRUCT && lhs.indirection == 0) {
+			var copyTok = synthetic_token(TokenType::IDENTIFIER, "copy");
+			var copyName: Name;
+			this.bind_name(&copyName, copyTok);
+
+			var args = new_vector();
+			var typePtr = copy_type(lhs);
+			typePtr.indirection = 1;
+			args.push(typePtr);
+
+			var copy = lhs.lookup_method_with_arguments(&copyName, args);
+
+			if(copy != null) {
+				var overload = new_node(NodeType::OVERLOAD, expr.position);
+				overload.overload.value = expr.assignment.rhs;
+				overload.overload.lhsType = lhs;
+				overload.overload.rhsType = typePtr;
+				overload.overload.op = expr.assignment.op;
+				
+				expr.assignment.rhs = overload;
+			}
+		}
 	}
 
 	expr.computedType = lhs;
@@ -1948,6 +1996,13 @@ function Parser.type_check_global_var(stmt: Node*) {
 			stmt.print_position();
 			eputs("Cannot assign type "); eputs(type_to_string(valueType)); eputs(" to variable expecting "); eputs(type_to_string(declType));
 			eputln();
+			exit(1);
+		}
+
+		// valueType and declType refer to the same struct
+		if(declType.type == DataType::STRUCT && declType.indirection == 0) {
+			stmt.print_position();
+			eputsln("Copying to a global variable is not supported");
 			exit(1);
 		}
 	}

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -1205,6 +1205,7 @@ function Parser.type_check_define_var(stmt: Node*) {
 
 	var name = stmt.variable.name;
 
+	// Check for Redeclaration
 	var redeclaration = this.lookup_same_scope_variable(&name);
 
 	if(redeclaration != null) {
@@ -1213,6 +1214,7 @@ function Parser.type_check_define_var(stmt: Node*) {
 		exit(1);
 	}
 
+	// Verify types with inference
 	if(declType.type == DataType::VOID && stmt.variable.value == null) {
 		stmt.print_position();
 		eputsln("Cannot infer type to variable without initial value");
@@ -1229,12 +1231,14 @@ function Parser.type_check_define_var(stmt: Node*) {
 
 	resolve_type(stmt.variable.type);
 
+	// Calculate offset from rbp
 	stmt.variable.stackOffset = this.currentBlock.block.currentStackOffset += declType.size_offset();
 
 	if(stmt.variable.stackOffset > this.currentFunction.funktion.localVariableStackOffset) {
 		this.currentFunction.funktion.localVariableStackOffset = stmt.variable.stackOffset;
 	}
 
+	// A value was provided
 	if(stmt.variable.value != null) {
 		if(valueType == null) {
 			if(stmt.variable.value.type == NodeType::ARRAY_INIT) {
@@ -1267,8 +1271,27 @@ function Parser.type_check_define_var(stmt: Node*) {
 			eputln();
 			exit(1);
 		}
+
+		// valueType and declType refer to the same struct
+		if(declType.type == DataType::STRUCT && declType.indirection == 0) {
+			var copyTok = synthetic_token(TokenType::IDENTIFIER, "copy");
+			var copyName: Name;
+			this.bind_name(&copyName, copyTok);
+
+			var args = new_vector();
+			var typePtr = copy_type(declType);
+			typePtr.indirection = 1;
+			args.push(typePtr);
+
+			var copy = declType.lookup_method_with_arguments(&copyName, args);
+
+			if(copy != null) {
+				stmt.variable.copyConstructor = true;
+			}
+		}
 	}
 
+	// A constructor was invoked
 	if(stmt.variable.arguments != null) {
 		if(stmt.variable.type.type != DataType::STRUCT || stmt.variable.type.indirection != 0) {
 			stmt.print_position();
@@ -1324,6 +1347,7 @@ function Parser.type_check_define_var(stmt: Node*) {
 		}
 	}
 
+	// Neither a value nor a constructor was given - attempt to call the default constructor
 	if(stmt.variable.value == null && stmt.variable.arguments == null 
 	   && stmt.variable.type.type == DataType::STRUCT && stmt.variable.type.indirection == 0) {
 		var constructorTok = synthetic_token(TokenType::IDENTIFIER, "constructor");

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -2007,10 +2007,85 @@ function Parser.type_check_global_var(stmt: Node*) {
 		}
 	}
 
+	// A constructor was invoked
 	if(stmt.variable.arguments != null) {
-		stmt.print_position();
-		eputsln("Constructing a global variable is not supported");
-		exit(1);
+		if(stmt.variable.type.type != DataType::STRUCT || stmt.variable.type.indirection != 0) {
+			stmt.print_position();
+			eputs("Cannot construct type "); eputs(type_to_string(stmt.variable.type)); eputsln(" as a global");
+			exit(1);
+		}
+
+		var constructorTok = synthetic_token(TokenType::IDENTIFIER, "constructor");
+		var constructorName: Name;
+		this.bind_name(&constructorName, constructorTok);
+
+		var constructor = stmt.variable.type.lookup_method(&constructorName);
+		// Perform default operation if constructor does not exist and there are no arguments
+		if(constructor == null) {
+			if(stmt.variable.arguments.size != 0) {
+				stmt.print_position();
+				eputs("Type "); eputs(type_to_string(stmt.variable.type)); eputs(" has no constructor: expected 0 arguments, got "); 
+				eputd(stmt.variable.arguments.size); eputln();
+				exit(1);
+			}
+			// Indicate to codegen to not generate a call to the constructor
+			stmt.variable.arguments = null;
+		}
+		else {
+			var argTypes = new_vector();
+			for(var i = 0; i < stmt.variable.arguments.size; ++i) {
+				var arg: Node* = stmt.variable.arguments.at(i);
+				this.type_check_expr(arg);
+
+				var argType: Type* = typeStack.pop();
+				argTypes.push(argType);
+			}
+
+			var constructor = stmt.variable.type.lookup_method_with_arguments(&constructorName, argTypes);
+
+			if(constructor == null) {
+				stmt.print_position();
+				eputs("Failed to resolve constructor"); eputs(" of type "); eputsln(type_to_string(stmt.variable.type));
+				eputs("Given argument types: "); eput_argument_types(argTypes); eputln();
+				exit(1);
+			}
+
+			var paramTypes = constructor.funktion.argTypes;
+			if(paramTypes == null) {
+				paramTypes = new_vector();
+				for(var i = 1; i < constructor.funktion.arguments.size; ++i) {
+					var type: Type* = (constructor.funktion.arguments.at(i) as Node*).variable.type;
+					resolve_type(type);
+					paramTypes.push(type);
+				}
+			}
+			stmt.variable.argTypes = paramTypes;
+		}
+	}
+
+	// Neither a value nor a constructor was given - attempt to call the default constructor
+	if(stmt.variable.value == null && stmt.variable.arguments == null 
+	   && stmt.variable.type.type == DataType::STRUCT && stmt.variable.type.indirection == 0) {
+		var constructorTok = synthetic_token(TokenType::IDENTIFIER, "constructor");
+		var constructorName: Name;
+		this.bind_name(&constructorName, constructorTok);
+
+		var constructors = stmt.variable.type.lookup_method(&constructorName);
+
+		if(constructors != null) {
+			stmt.variable.arguments = new_vector();
+			
+			var argTypes = new_vector();
+			var constructor = stmt.variable.type.lookup_method_with_arguments(&constructorName, argTypes);
+
+			if(constructor == null) {
+				stmt.print_position();
+				eputs("Could not resolve default constructor of type "); eputsln(type_to_string(stmt.variable.type));
+				exit(1);
+			}
+
+			stmt.variable.argTypes = argTypes;
+		}
 	}
 
 	this.globalVars.push(stmt);

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -2001,9 +2001,20 @@ function Parser.type_check_global_var(stmt: Node*) {
 
 		// valueType and declType refer to the same struct
 		if(declType.type == DataType::STRUCT && declType.indirection == 0) {
-			stmt.print_position();
-			eputsln("Copying to a global variable is not supported");
-			exit(1);
+			var copyTok = synthetic_token(TokenType::IDENTIFIER, "copy");
+			var copyName: Name;
+			this.bind_name(&copyName, copyTok);
+
+			var args = new_vector();
+			var typePtr = copy_type(declType);
+			typePtr.indirection = 1;
+			args.push(typePtr);
+
+			var copy = declType.lookup_method_with_arguments(&copyName, args);
+
+			if(copy != null) {
+				stmt.variable.copyConstructor = true;
+			}
 		}
 	}
 

--- a/std/map.zpr
+++ b/std/map.zpr
@@ -27,7 +27,24 @@ namespace std::map {
 	}
 
 	function HashMap.deconstructor() {
+		for(var i = 0; i < this.capacity; ++i) {
+			var item = this.items[i];
+			if(item.key != null) {
+				delete item.key;
+			}
+		}
 		delete[] this.items;
+	}
+
+	function HashMap.copy(other: HashMap*) {
+		this.count = other.count;
+		this.capacity = other.capacity;
+		this.items = new HashItem[this.capacity];
+		for(var i = 0; i < this.capacity; ++i) {
+			var item = other.items[i];
+			this.items[i].key = item.key == null ? null : strcpy(item.key);
+			this.items[i].value = item.value;
+		}
 	}
 
 	function HashMap.adjustCapacity() {
@@ -82,7 +99,7 @@ namespace std::map {
 			++this.count;
 		}
 
-		item.key = key;
+		item.key = strcpy(key);
 		item.value = value;
 	}
 

--- a/std/string.zpr
+++ b/std/string.zpr
@@ -24,6 +24,16 @@ function strcat(dst: i8*, src: i8*): i8* {
 	return dst;
 }
 
+function strcpy(src: i8*): i8* {
+	var length = strlen(src);
+	var dst = new i8[length + 1];
+	for(var i = 0; src[i]; ++i) {
+		dst[i] = src[i];
+	}
+	dst[length] = '\0';
+	return dst;
+}
+
 function str_reverse(str: i8*, length: int) {
 	var start = 0;
 	var end = length - 1;

--- a/tests/core.sh
+++ b/tests/core.sh
@@ -2322,6 +2322,30 @@ function main(): int {
 }
 "
 
+assert_stdout "10
+15" "
+import \"std/io.zpr\";
+
+struct Point {
+	x: int;
+	y: int;
+}
+
+function Point.constructor(x: int, y: int) {
+	this.x = x;
+	this.y = y;
+}
+
+var gpoint: Point(10, 15);
+
+function main(): int {
+	putd(gpoint.x); putln();
+	putd(gpoint.y); putln();
+
+	return 0;
+}
+"
+
 echo " Done"
 
 echo -n "Function Overloading: "
@@ -2528,6 +2552,150 @@ function Person.say_hi() {
 function main(): int {
 	var person: Person(\"Alice\");
 	person.say_hi();
+
+	return 0;
+}
+"
+
+echo " Done"
+
+echo -n "Copy Constructors: "
+
+assert_stdout "Cool Program
+Hello, World!" "
+import \"std/io.zpr\";
+
+struct String {
+	chars: i8*;
+	length: uint;
+}
+
+function String.constructor() {
+	this.chars = \"\";
+	this.length = 0;
+}
+
+function String.constructor(str: i8*) {
+	this.set(str);
+}
+
+function String.deconstructor() {
+	delete[] this.chars;
+}
+
+function String.copy(other: String*) {
+	this.chars = new i8[other.length + 1];
+	memcpy(this.chars, other.chars, other.length + 1);
+	this.length = other.length;
+}
+
+function String.set(str: i8*) {
+	this.length = strlen(str);
+	this.chars = new i8[this.length + 1];
+	memcpy(this.chars, str, this.length + 1);
+}
+
+function main(): int {
+	var str: String(\"Hello, World!\");
+	var str2 = str;
+
+	str.set(\"Cool Program\");
+
+	putsln(str.chars);
+	putsln(str2.chars);
+
+	return 0;
+}
+"
+
+assert_stdout "Cool Program
+Hello, World!
+Hello, World!" "
+import \"std/io.zpr\";
+
+struct String {
+	chars: i8*;
+	length: uint;
+}
+
+function String.constructor() {
+	this.chars = \"\";
+	this.length = 0;
+}
+
+function String.constructor(str: i8*) {
+	this.set(str);
+}
+
+function String.deconstructor() {
+	delete[] this.chars;
+}
+
+function String.copy(other: String*) {
+	this.chars = new i8[other.length + 1];
+	memcpy(this.chars, other.chars, other.length + 1);
+	this.length = other.length;
+}
+
+function String.set(str: i8*) {
+	this.length = strlen(str);
+	this.chars = new i8[this.length + 1];
+	memcpy(this.chars, str, this.length + 1);
+}
+
+function check_eq(a1: any*, a2: any*) {
+	if(a1 != a2) {
+		putsln(\"Not equal!\");
+	}
+}
+
+function main(): int {
+	var str: String(\"Hello, World!\");
+	var str2: String;
+
+	var str3 = str2 = str;
+
+	str.set(\"Cool Program\");
+
+	putsln(str.chars);
+	putsln(str2.chars);
+	putsln(str3.chars);
+
+	return 0;
+}
+"
+
+assert_stdout "Copied!
+5
+6
+5
+6" "
+import \"std/io.zpr\";
+
+struct Point {
+	x: int;
+	y: int;
+}
+
+function Point.constructor(x: int, y: int) {
+	this.x = x;
+	this.y = y;
+}
+
+function Point.copy(o: Point*) {
+	this.x = o.x;
+	this.y = o.y;
+	putsln(\"Copied!\");
+}
+
+var gpoint: Point(5, 6);
+var gpoint2 = gpoint;
+
+function main(): int {
+	putd(gpoint.x); putln();
+	putd(gpoint.y); putln();
+	putd(gpoint2.x); putln();
+	putd(gpoint2.y); putln();
 
 	return 0;
 }


### PR DESCRIPTION
Allows the declaration of a `T.copy(T*)` method, which is called when a struct is copied.
E.g.
```
import "std/io.zpr";
struct Point {
  x: int;
  y: int;
}

function Point.copy(o: Point*) {
  this.x = o.x;
  this.y = o.y;
  putsln("Called");
}

function main(): int {
  var p1: Point;
  var p2 = p1;  // (1) Called
  var p3: Point;
  p3 = p2;      // (2) Called
  return 0;
}
```
This allows for structs to manage (and deep-copy) allocated / complex data.

Fixes #15 