### PR TITLE
Fix issue #21 (Stack Allocated Structures are Deconstructed before Returning)

### DIFF
--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -1198,7 +1198,15 @@ function generate_delete_array(stmt: Node*, out: File*) {
 }
 
 function generate_return(stmt: Node*, out: File*) {
+	if(stmt.ret.value != null) {
+		generate_expr(stmt.ret.value, out);
+	}
+	else {
+		out.putsln("    xor rax, rax");
+	}
+
 	if(stmt.ret.variables != null) {
+		out.putsln("    push rax");
 		for(var i = 0; i < stmt.ret.variables.size; ++i) {
 			var variable: Node* = stmt.ret.variables.at(i);
 
@@ -1213,10 +1221,9 @@ function generate_return(stmt: Node*, out: File*) {
 				out.puts("    call _M"); out.put_name(&variable.variable.type.name); out.puts("_"); out.put_name(&deconstructorName); out.putln();
 			}
 		}
+		out.putsln("    pop rax");
 	}
 
-	if(stmt.ret.value != null)
-		generate_expr(stmt.ret.value, out);
 	out.putsln("    leave");
 	out.putsln("    ret");
 }


### PR DESCRIPTION
# Description
Fixes the issue described in issue #21.

Also fixes a bug where the return value would not default to 0 (in void functions).
This creates an issue where the following program produces an incorrect return code:
```zephyr
function main() {
	var x = 15;
}
```
Before this change it would return `15`, now correctly returns `0`.

Closes #21 