### PR TITLE
Pass and Return Structures

### DIFF
--- a/bootstrap/bootstrap_x86_64_linux.yasm
+++ b/bootstrap/bootstrap_x86_64_linux.yasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ff9df462b8019f5e1eabecaa5b8edba213ab2d6a1206ce86833bfe754dfd0e9e
-size 886028
+oid sha256:aad103b8759abc727140eabdeadcd7218041e9b69ada8739dba145186d624c7f
+size 924866

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -278,6 +278,7 @@ struct Node {
 			isStructural: bool;
 			type: Type*;
 			structureVarOffset: int;
+			copyConstructor: bool;
 		};
 
 		overload: struct {

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -219,6 +219,7 @@ struct Node {
 
 			stackOffset: int;
 			unionField: int;
+			isArgument: bool;
 		};
 
 		constant: struct {

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -169,6 +169,7 @@ struct Node {
 			argTypes: Vector*;
 
 			localVariableStackOffset: int;
+			temporaryStackOffset: int;
 			argumentStackOffset: int;
 
 			used: bool;

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -127,6 +127,7 @@ struct Node {
 	position: Token*;
 	lvalue: LValue;
 	computedType: Type*;
+	temporaries: Vector*;
 
 	union {
 		unary: Node*;

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -169,6 +169,7 @@ struct Node {
 			argTypes: Vector*;
 
 			localVariableStackOffset: int;
+			argumentStackOffset: int;
 
 			used: bool;
 			dced: bool;
@@ -273,6 +274,9 @@ struct Node {
 		ret: struct {
 			value: Node*;
 			variables: Vector*;
+			isStructural: bool;
+			type: Type*;
+			structureVarOffset: int;
 		};
 
 		overload: struct {

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -1233,10 +1233,28 @@ function generate_return(stmt: Node*, out: File*) {
 
 	if(stmt.ret.isStructural) {
 		out.puts("    mov rcx, QWORD [rbp-"); out.putd(stmt.ret.structureVarOffset); out.putsln("]");
-	
-		generate_copy(stmt.ret.type.fields, 0, out);
 
-		out.putsln("    mov rax, rcx");
+		if(stmt.ret.copyConstructor) {
+			var copyTok = synthetic_token(TokenType::IDENTIFIER, "copy");
+			var copyName: Name;
+			parser.bind_name(&copyName, copyTok);
+
+			var args = new_vector();
+			var typePtr = copy_type(stmt.ret.type);
+			typePtr.indirection = 1;
+			args.push(typePtr);
+
+			out.putsln("    push rcx");
+			out.putsln("    mov rdi, rcx");
+			out.putsln("    mov rsi, rax");
+			out.puts("    call _M"); out.put_arguments(args);
+			out.put_name(&stmt.ret.type.name); out.puts("_"); out.put_name(&copyName); out.putln();
+			out.putsln("    pop rax");
+		}
+		else {
+			generate_copy(stmt.ret.type.fields, 0, out);
+			out.putsln("    mov rax, rcx");
+		}
 	}
 
 	if(stmt.ret.variables != null && !stmt.ret.variables.empty()) {

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -426,6 +426,18 @@ function generate_call(expr: Node*, out: File*) {
 		}
 	}
 
+	if(expr.computedType.is_structural()) {
+		out.puts("    lea rax, [rbp-"); out.putd(expr.funktion.argumentStackOffset); out.putsln("]");
+		if(localIntRegUse < INT_ARG_COUNT) {
+			out.puts("    mov "); out.puts(INT_ARG_REGISTERS[localIntRegUse]); out.putsln(", rax");
+			++intRegistersInUse;
+			++localIntRegUse;
+		}
+		else {
+			out.putsln("    push rax");
+		}
+	}
+
 	intRegistersInUse -= localIntRegUse;
 	floatRegistersInUse -= localFloatRegUse;
 
@@ -1205,7 +1217,15 @@ function generate_return(stmt: Node*, out: File*) {
 		out.putsln("    xor rax, rax");
 	}
 
-	if(stmt.ret.variables != null) {
+	if(stmt.ret.isStructural) {
+		out.puts("    mov rcx, QWORD [rbp-"); out.putd(stmt.ret.structureVarOffset); out.putsln("]");
+	
+		generate_copy(stmt.ret.type.fields, 0, out);
+
+		out.putsln("    mov rax, rcx");
+	}
+
+	if(stmt.ret.variables != null && !stmt.ret.variables.empty()) {
 		out.putsln("    push rax");
 		for(var i = 0; i < stmt.ret.variables.size; ++i) {
 			var variable: Node* = stmt.ret.variables.at(i);
@@ -1382,6 +1402,18 @@ function generate_function(funktion: Node*, out: File*) {
 				out.puts("    mov QWORD [rbp-"); out.putd(arg.variable.stackOffset); out.putsln("], rax");
 				++stackUse;
 			}
+		}
+	}
+
+	if(funktion.funktion.returnType.is_structural()) {
+		if(intRegUse < INT_ARG_COUNT) {
+			out.puts("    mov QWORD [rbp-"); out.putd(funktion.funktion.argumentStackOffset); out.puts("], "); out.putsln(INT_ARG_REGISTERS[intRegUse]);
+			++intRegUse;
+		}
+		else {
+			out.puts("    mov rax, QWORD [rbp+"); out.putd(8 + (8 * (funktion.funktion.arguments.size - (intRegUse + floatRegUse) - stackUse))); out.putsln("]");
+			out.puts("    mov QWORD [rbp-"); out.putd(funktion.funktion.argumentStackOffset); out.putsln("], rax");
+			++stackUse;
 		}
 	}
 

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -14,6 +14,7 @@ var intRegistersInUse = 0;
 var floatRegistersInUse = 0;
 var continueLabel = 0;
 var breakLabel = 0;
+var currentlocalVariableOffset = 0;
 
 var parser: Parser*;
 
@@ -427,7 +428,7 @@ function generate_call(expr: Node*, out: File*) {
 	}
 
 	if(expr.computedType.is_structural()) {
-		out.puts("    lea rax, [rbp-"); out.putd(expr.funktion.argumentStackOffset); out.putsln("]");
+		out.puts("    lea rax, [rbp-"); out.putd(currentlocalVariableOffset + expr.funktion.argumentStackOffset); out.putsln("]");
 		if(localIntRegUse < INT_ARG_COUNT) {
 			out.puts("    mov "); out.puts(INT_ARG_REGISTERS[localIntRegUse]); out.putsln(", rax");
 			++intRegistersInUse;
@@ -503,7 +504,7 @@ function generate_method_call(parent: Node*, parentType: Type*, name: Name*, arg
 	}
 
 	if(returnType != null && returnType.is_structural()) {
-		out.puts("    lea rax, [rbp-"); out.putd(argumentOffset); out.putsln("]");
+		out.puts("    lea rax, [rbp-"); out.putd(currentlocalVariableOffset + argumentOffset); out.putsln("]");
 		if(localIntRegUse < INT_ARG_COUNT) {
 			out.puts("    mov "); out.puts(INT_ARG_REGISTERS[localIntRegUse]); out.putsln(", rax");
 			++intRegistersInUse;
@@ -1352,10 +1353,12 @@ function generate_function(funktion: Node*, out: File*) {
 	out.putsln("    push rbp");
 	out.putsln("    mov rbp, rsp");
 
-	var stackDepth = ceil_multiple(funktion.funktion.localVariableStackOffset, 16);
+	var stackDepth = ceil_multiple(funktion.funktion.localVariableStackOffset + funktion.funktion.temporaryStackOffset, 16);
 	if(stackDepth != 0) {
 		out.puts("    sub rsp, "); out.putd(stackDepth); out.putln();
 	}
+
+	currentlocalVariableOffset = funktion.funktion.localVariableStackOffset;
 
 	var intRegUse = 0;
 	var floatRegUse = 0;

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -1342,6 +1342,36 @@ function generate_function(funktion: Node*, out: File*) {
 				++stackUse;
 			}
 		}
+		else if(arg.variable.type.is_structural()) {
+			if(intRegUse < INT_ARG_COUNT) {
+				out.puts("    mov rax, "); out.putsln(INT_ARG_REGISTERS[intRegUse]);
+				out.puts("    lea rcx, [rbp-"); out.putd(arg.variable.stackOffset); out.putsln("]");
+				++intRegUse;
+			}
+			else {
+				out.puts("    mov rax, QWORD [rbp+"); out.putd(8 + (8 * (funktion.funktion.arguments.size - (intRegUse + floatRegUse) - stackUse))); out.putsln("]");
+				out.puts("    lea rcx, [rbp-"); out.putd(arg.variable.stackOffset); out.putsln("]");
+				++stackUse;
+			}
+			if(arg.variable.copyConstructor) {
+				var copyTok = synthetic_token(TokenType::IDENTIFIER, "copy");
+				var copyName: Name;
+				parser.bind_name(&copyName, copyTok);
+
+				var args = new_vector();
+				var typePtr = copy_type(arg.variable.type);
+				typePtr.indirection = 1;
+				args.push(typePtr);
+
+				out.putsln("    mov rdi, rcx");
+				out.putsln("    mov rsi, rax");
+				out.puts("    call _M"); out.put_arguments(args);
+				out.put_name(&arg.variable.type.name); out.puts("_"); out.put_name(&copyName); out.putln();
+			}
+			else {
+				generate_copy(arg.variable.type.fields, 0, out);
+			}
+		}
 		else {
 			if(intRegUse < INT_ARG_COUNT) {
 				out.puts("    mov QWORD [rbp-"); out.putd(arg.variable.stackOffset); out.puts("], "); out.putsln(INT_ARG_REGISTERS[intRegUse]);

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -453,7 +453,7 @@ function generate_call(expr: Node*, out: File*) {
 	}
 }
 
-function generate_method_call(parent: Node*, parentType: Type*, name: Name*, arguments: Vector*, argTypes: Vector*, out: File*) {
+function generate_method_call(parent: Node*, parentType: Type*, name: Name*, arguments: Vector*, argTypes: Vector*, returnType: Type*, argumentOffset: int, out: File*) {
 	for(var i = 0; i < intRegistersInUse; ++i) {
 		out.puts("    push "); out.putsln(INT_ARG_REGISTERS[i]);
 	}
@@ -502,6 +502,18 @@ function generate_method_call(parent: Node*, parentType: Type*, name: Name*, arg
 		}
 	}
 
+	if(returnType != null && returnType.is_structural()) {
+		out.puts("    lea rax, [rbp-"); out.putd(argumentOffset); out.putsln("]");
+		if(localIntRegUse < INT_ARG_COUNT) {
+			out.puts("    mov "); out.puts(INT_ARG_REGISTERS[localIntRegUse]); out.putsln(", rax");
+			++intRegistersInUse;
+			++localIntRegUse;
+		}
+		else {
+			out.putsln("    push rax");
+		}
+	}
+
 	intRegistersInUse -= localIntRegUse;
 	floatRegistersInUse -= localFloatRegUse;
 
@@ -521,7 +533,8 @@ function generate_method_call(parent: Node*, parentType: Type*, name: Name*, arg
 }
 
 function generate_call_method(expr: Node*, out: File*) {
-	generate_method_call(expr.funktion.parent, expr.funktion.parentType, &expr.funktion.name, expr.funktion.arguments, expr.funktion.argTypes, out);
+	generate_method_call(expr.funktion.parent, expr.funktion.parentType, &expr.funktion.name, expr.funktion.arguments, expr.funktion.argTypes,
+	expr.computedType, expr.funktion.argumentStackOffset, out);
 }
 
 function generate_ternary(expr: Node*, out: File*) {
@@ -670,7 +683,7 @@ function generate_assign(expr: Node*, out: File*) {
 		var args = new_vector();
 		args.push(expr.assignment.rhs.overload.rhsType);
 
-		generate_method_call(null, expr.assignment.rhs.overload.lhsType, Typecheck::get_name_from_overload(expr.assignment.rhs.overload.op), null, args, out);
+		generate_method_call(null, expr.assignment.rhs.overload.lhsType, Typecheck::get_name_from_overload(expr.assignment.rhs.overload.op), null, args, null, 0, out);
 		out.putsln("    pop rax");
 		return;
 	}
@@ -736,7 +749,7 @@ function generate_new(expr: Node*, out: File*) {
 		parser.bind_name(&constructorName, constructorTok);
 
 		out.putsln("    push rax");
-		generate_method_call(null, expr.constructor.type, &constructorName, expr.constructor.arguments, expr.constructor.argTypes, out);
+		generate_method_call(null, expr.constructor.type, &constructorName, expr.constructor.arguments, expr.constructor.argTypes, null, 0, out);
 		out.putsln("    pop rax");
 	}
 }
@@ -778,7 +791,7 @@ function generate_new_array(expr: Node*, out: File*) {
 		out.puts("    jnb .l"); out.putu(loopEnd); out.putln(); // exit the loop if i >= length
 
 		// address (offsetted) is already in rax at this point
-		generate_method_call(null, expr.constructor.type, &constructorName, null, null, out);
+		generate_method_call(null, expr.constructor.type, &constructorName, null, null, null, 0, out);
 
 		// Set registers as such:
 		// rcx - i
@@ -1120,7 +1133,7 @@ function generate_define_var(stmt: Node*, out: File*) {
 
 		out.puts("    lea rax, [rbp-"); out.putd(stmt.variable.stackOffset); out.putsln("]");
 
-		generate_method_call(null, stmt.variable.type, &constructorName, stmt.variable.arguments, stmt.variable.argTypes, out);
+		generate_method_call(null, stmt.variable.type, &constructorName, stmt.variable.arguments, stmt.variable.argTypes, null, 0, out);
 	}
 }
 
@@ -1179,7 +1192,7 @@ function generate_delete_array(stmt: Node*, out: File*) {
 		out.puts("    jnb .l"); out.putu(loopEnd); out.putln(); // exit the loop if i >= length
 
 		// address (offsetted) is already in rax at this point
-		generate_method_call(null, stmt.deconstructor.elementType, &deconstructorName, null, null, out);
+		generate_method_call(null, stmt.deconstructor.elementType, &deconstructorName, null, null, null, 0, out);
 
 		// Set registers as such:
 		// rcx - i
@@ -1570,7 +1583,7 @@ function Parser.generate_program(ast: Node*, out: File*) {
 
 			out.puts("    lea rax, [_G"); out.put_name(&variable.variable.name); out.putsln("]");
 
-			generate_method_call(null, variable.variable.type, &constructorName, variable.variable.arguments, variable.variable.argTypes, out);
+			generate_method_call(null, variable.variable.type, &constructorName, variable.variable.arguments, variable.variable.argTypes, null, 0, out);
 		}
 	}
 

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -1326,6 +1326,23 @@ function generate_statement(stmt: Node*, out: File*) {
 			exit(1);
 		}
 	}
+
+	if(stmt.temporaries != null) {
+		for(var i = 0; i < stmt.temporaries.size; ++i) {
+			var temp: Node* = stmt.temporaries.at(i);
+			
+			var deconstructorTok = synthetic_token(TokenType::IDENTIFIER, "deconstructor");
+			var deconstructorName: Name;
+			parser.bind_name(&deconstructorName, deconstructorTok);
+
+			var deconstructor = temp.computedType.lookup_method(&deconstructorName);
+
+			if(deconstructor != null) {
+				out.puts("    lea rdi, [rbp-"); out.putd(temp.funktion.argumentStackOffset); out.putsln("]");
+				out.puts("    call _M"); out.put_name(&temp.computedType.name); out.puts("_"); out.put_name(&deconstructorName); out.putln();
+			}
+		}
+	}
 }
 
 function generate_block(block: Node*, out: File*) {

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -226,6 +226,20 @@ function Parser.dce_statement(stmt: Node*) {
 		NodeType::RETURN -> {
 			if(stmt.ret.value != null)
 				this.dce_expression(stmt.ret.value);
+
+			if(stmt.ret.copyConstructor) {
+				var copyTok = synthetic_token(TokenType::IDENTIFIER, "copy");
+				var copyName: Name;
+				this.bind_name(&copyName, copyTok);
+
+				var args = new_vector();
+				var typePtr = copy_type(stmt.ret.type);
+				typePtr.indirection = 1;
+				args.push(typePtr);
+
+				var copy = stmt.ret.type.lookup_method_with_arguments(&copyName, args);
+				this.dce_function(copy);
+			}
 			// Variables are dce'd by dce_block
 		}
 		NodeType::DELETE -> {

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -288,6 +288,24 @@ function Parser.dce_statement(stmt: Node*) {
 }
 
 function Parser.dce_function(funktion: Node*) {
+	for(var i = 0; i < funktion.funktion.arguments.size; ++i) {
+		var arg: Node* = funktion.funktion.arguments.at(i);
+
+		if(arg.variable.copyConstructor) {
+			var copyTok = synthetic_token(TokenType::IDENTIFIER, "copy");
+			var copyName: Name;
+			this.bind_name(&copyName, copyTok);
+
+			var args = new_vector();
+			var typePtr = copy_type(arg.variable.type);
+			typePtr.indirection = 1;
+			args.push(typePtr);
+
+			var copy = arg.variable.type.lookup_method_with_arguments(&copyName, args);
+			this.dce_function(copy);
+		}
+	}
+
 	funktion.funktion.used = true;
 	if(!funktion.funktion.hasImplicitBody)
 		this.dce_block(funktion.funktion.body);

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -198,7 +198,9 @@ function Parser.dce_statement(stmt: Node*) {
 					args.push(typePtr);
 
 					var copy = stmt.variable.type.lookup_method_with_arguments(&copyName, args);
-					this.dce_function(copy);
+					if(!copy.funktion.dced) {
+						this.dce_function(copy);
+					}
 				}
 			}
 			if(stmt.variable.arguments != null) {
@@ -238,7 +240,10 @@ function Parser.dce_statement(stmt: Node*) {
 				args.push(typePtr);
 
 				var copy = stmt.ret.type.lookup_method_with_arguments(&copyName, args);
-				this.dce_function(copy);
+
+				if(!copy.funktion.dced) {
+					this.dce_function(copy);
+				}
 			}
 			// Variables are dce'd by dce_block
 		}
@@ -299,6 +304,24 @@ function Parser.dce_statement(stmt: Node*) {
 			exit(1);
 		}
 	}
+
+	if(stmt.temporaries != null && !stmt.temporaries.empty()) {
+		for(var i = 0; i < stmt.temporaries.size; ++i) {
+			var temp: Node* = stmt.temporaries.at(i);
+
+			var deconstructorTok = synthetic_token(TokenType::IDENTIFIER, "deconstructor");
+			var deconstructorName: Name;
+			this.bind_name(&deconstructorName, deconstructorTok);
+
+			var argTypes = new_vector();
+			var deconstructor = temp.computedType.lookup_method_with_arguments(&deconstructorName, argTypes);
+
+			if(deconstructor != null && !deconstructor.funktion.dced) {
+				deconstructor.funktion.dced = true;
+				this.dce_function(deconstructor);
+			}
+		}
+	}
 }
 
 function Parser.dce_function(funktion: Node*) {
@@ -316,7 +339,9 @@ function Parser.dce_function(funktion: Node*) {
 			args.push(typePtr);
 
 			var copy = arg.variable.type.lookup_method_with_arguments(&copyName, args);
-			this.dce_function(copy);
+			if(!copy.funktion.dced) {
+				this.dce_function(copy);
+			}
 		}
 	}
 
@@ -371,7 +396,9 @@ function Parser.dce() {
 				args.push(typePtr);
 
 				var copy = gvar.variable.type.lookup_method_with_arguments(&copyName, args);
-				this.dce_function(copy);
+				if(!copy.funktion.dced) {
+					this.dce_function(copy);
+				}
 			}
 		}
 

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -1725,6 +1725,23 @@ function Parser.type_check_return(stmt: Node*) {
 	if(expectedType.is_structural()) {
 		stmt.ret.isStructural = true;
 		stmt.ret.structureVarOffset = this.currentFunction.funktion.argumentStackOffset;
+
+		if(expectedType.type == DataType::STRUCT && expectedType.indirection == 0) {
+			var copyTok = synthetic_token(TokenType::IDENTIFIER, "copy");
+			var copyName: Name;
+			this.bind_name(&copyName, copyTok);
+
+			var args = new_vector();
+			var typePtr = copy_type(expectedType);
+			typePtr.indirection = 1;
+			args.push(typePtr);
+
+			var copy = expectedType.lookup_method_with_arguments(&copyName, args);
+
+			if(copy != null) {
+				stmt.ret.copyConstructor = true;
+			}
+		}
 	}
 
 	stmt.ret.type = expectedType;

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -1886,15 +1886,29 @@ function Parser.type_check_function(funktion: Node*) {
 	for(var i = 0; i < funktion.funktion.arguments.size; ++i) {
 		var arg: Node* = funktion.funktion.arguments.at(i);
 
+		resolve_type(arg.variable.type);
+
 		if(arg.variable.type.isArray) {
 			arg.print_position();
 			eputsln("Arrays cannot be used as function arguments - consider using a pointer instead");
 			exit(1);
 		}
-		else if(arg.variable.type.is_structural()) {
-			arg.print_position();
-			eputsln("Structs cannot be used as function arguments - consider using a pointer instead");
-			exit(1);
+
+		if(arg.variable.type.type == DataType::STRUCT && arg.variable.type.indirection == 0) {
+			var copyTok = synthetic_token(TokenType::IDENTIFIER, "copy");
+			var copyName: Name;
+			this.bind_name(&copyName, copyTok);
+
+			var args = new_vector();
+			var typePtr = copy_type(arg.variable.type);
+			typePtr.indirection = 1;
+			args.push(typePtr);
+
+			var copy = arg.variable.type.lookup_method_with_arguments(&copyName, args);
+
+			if(copy != null) {
+				arg.variable.copyConstructor = true;
+			}
 		}
 
 		//FIXME Have the correct qualifiers and registers used in codegen.zpr for arguments

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -10,6 +10,7 @@ var namespaces = new_vector();
 
 var checkingLoop = false;
 var temporaryOffset = 0;
+var temporaries = new_vector();
 
 function Type.is_integral(): bool {
 	return this.indirection == 0 && (
@@ -759,6 +760,26 @@ function Parser.type_check_call(expr: Node*) {
 
 	if(func.funktion.returnType.is_structural()) {
 		expr.funktion.argumentStackOffset = temporaryOffset += func.funktion.returnType.size_offset();
+	
+		if(func.funktion.returnType.type == DataType::STRUCT) {
+			var deconstructorTok = synthetic_token(TokenType::IDENTIFIER, "deconstructor");
+			var deconstructorName: Name;
+			this.bind_name(&deconstructorName, deconstructorTok);
+
+			var argTypes = new_vector();
+			var deconstructors = func.funktion.returnType.lookup_method(&deconstructorName);
+
+			if(deconstructors != null) {
+				var argTypes = new_vector();
+				var deconstructor = func.funktion.returnType.lookup_method_with_arguments(&deconstructorName, argTypes);
+				if(deconstructor == null) {
+					expr.print_position();
+					eputs("The deconstructor of type "); eputs(type_to_string(func.funktion.returnType)); eputsln(" must have 0 arguments");
+					exit(1);
+				}
+				temporaries.push(expr);
+			}
+		}
 	}
 
 	expr.funktion.argTypes = paramTypes;
@@ -1843,6 +1864,19 @@ function Parser.type_check_statement(stmt: Node*) {
 
 	if(temporaryOffset > this.currentFunction.funktion.temporaryStackOffset) {
 		this.currentFunction.funktion.temporaryStackOffset = temporaryOffset;
+	}
+
+	if(!temporaries.empty()) {
+		var temporariesToDeconstruct = new_vector();
+
+		for(var i = 0; i < temporaries.size; ++i) {
+			var temp: Node* = temporaries.at(i);
+			temporariesToDeconstruct.push(temp);
+		}
+		stmt.temporaries = temporariesToDeconstruct;
+		
+		// Empty the array of temporaries for the next statement
+		temporaries.size = 0;
 	}
 }
 

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -756,6 +756,14 @@ function Parser.type_check_call(expr: Node*) {
 		}
 	}
 
+	if(func.funktion.returnType.is_structural()) {
+		expr.funktion.argumentStackOffset = this.currentBlock.block.currentStackOffset += func.funktion.returnType.size_offset();
+
+		if(expr.funktion.argumentStackOffset > this.currentFunction.funktion.localVariableStackOffset) {
+			this.currentFunction.funktion.localVariableStackOffset = expr.funktion.argumentStackOffset;
+		}
+	}
+
 	expr.funktion.argTypes = paramTypes;
 	expr.computedType = func.funktion.returnType;
 	typeStack.push(func.funktion.returnType);
@@ -1713,6 +1721,13 @@ function Parser.type_check_return(stmt: Node*) {
 		exit(1);
 	}
 
+	if(expectedType.is_structural()) {
+		stmt.ret.isStructural = true;
+		stmt.ret.structureVarOffset = this.currentFunction.funktion.argumentStackOffset;
+	}
+
+	stmt.ret.type = expectedType;
+
 	if(this.currentBlock.block.variables.size > 0) {
 		stmt.ret.variables = new_vector();
 		
@@ -1726,8 +1741,23 @@ function Parser.type_check_return(stmt: Node*) {
 					continue;
 				}
 
-				// Deconstructor is verified by type_check_block
-				stmt.ret.variables.push(variable);
+				var deconstructorTok = synthetic_token(TokenType::IDENTIFIER, "deconstructor");
+				var deconstructorName: Name;
+				this.bind_name(&deconstructorName, deconstructorTok);
+
+				var deconstructors = variable.variable.type.lookup_method(&deconstructorName);
+
+				if(deconstructors != null) {
+					var argTypes = new_vector();
+					var deconstructor = variable.variable.type.lookup_method_with_arguments(&deconstructorName, argTypes);
+
+					if(deconstructor == null) {
+						variable.print_position();
+						eputs("The deconstructor of type "); eputs(type_to_string(variable.variable.type)); eputsln(" must have 0 arguments"); 
+						exit(1);
+					}
+					stmt.ret.variables.push(variable);
+				}
 			}
 
 			block = block.block.parent;
@@ -1923,11 +1953,11 @@ function Parser.type_check_function(funktion: Node*) {
 		exit(1);
 	}
 	else if(funktion.funktion.returnType.is_structural()) {
-		funktion.print_position();
-		eputsln("Structs cannot be used as function return types - consider using a pointer instead");
-		exit(1);
+		// Space for an implicit pointer
+		stackOffset += 8;
 	}
 
+	funktion.funktion.argumentStackOffset = stackOffset;
 	funktion.funktion.body.block.currentStackOffset = stackOffset;
 	funktion.funktion.localVariableStackOffset = stackOffset;
 

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -376,6 +376,8 @@ function Parser.lookup_scope_variable(name: Name*, block: Node*): Node* {
 	for(var i = 0; i < block.block.variables.size; ++i) {
 		var variable: Node* = block.block.variables.at(i);
 
+		if(variable.variable.isArgument) continue;
+
 		if(variable.variable.name.equals(name)) {
 			return variable;
 		}
@@ -1881,7 +1883,11 @@ function Parser.type_check_statement(stmt: Node*) {
 }
 
 function Parser.type_check_block(block: Node*) {
-	block.block.variables = new_vector();
+	this.type_check_block(block, new_vector());
+}
+
+function Parser.type_check_block(block: Node*, variables: Vector*) {
+	block.block.variables = variables;
 	block.block.currentStackOffset = this.currentBlock.block.currentStackOffset;
 	this.currentBlock = block;
 
@@ -1971,6 +1977,8 @@ function Parser.type_check_function(funktion: Node*) {
 		}
 	}
 
+	var arguments = new_vector();
+
 	for(var i = 0; i < funktion.funktion.arguments.size; ++i) {
 		var arg: Node* = funktion.funktion.arguments.at(i);
 
@@ -2003,6 +2011,8 @@ function Parser.type_check_function(funktion: Node*) {
 		stackOffset += ceil_multiple(arg.variable.type.size(), 8);
 
 		arg.variable.stackOffset = stackOffset;
+		arg.variable.isArgument = true;
+		arguments.push(arg);
 	}
 
 	if(funktion.funktion.returnType.isArray) {
@@ -2022,7 +2032,7 @@ function Parser.type_check_function(funktion: Node*) {
 	this.currentFunction = funktion;
 
 	this.currentBlock = funktion.funktion.body;
-	this.type_check_block(funktion.funktion.body);
+	this.type_check_block(funktion.funktion.body, arguments);
 
 	if(!funktion.funktion.body.block.hasReturned) {
 		if(funktion.funktion.returnType.is_void()) {

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -9,6 +9,7 @@ var definedTypes = new_vector();
 var namespaces = new_vector();
 
 var checkingLoop = false;
+var temporaryOffset = 0;
 
 function Type.is_integral(): bool {
 	return this.indirection == 0 && (
@@ -757,11 +758,7 @@ function Parser.type_check_call(expr: Node*) {
 	}
 
 	if(func.funktion.returnType.is_structural()) {
-		expr.funktion.argumentStackOffset = this.currentBlock.block.currentStackOffset += func.funktion.returnType.size_offset();
-
-		if(expr.funktion.argumentStackOffset > this.currentFunction.funktion.localVariableStackOffset) {
-			this.currentFunction.funktion.localVariableStackOffset = expr.funktion.argumentStackOffset;
-		}
+		expr.funktion.argumentStackOffset = temporaryOffset += func.funktion.returnType.size_offset();
 	}
 
 	expr.funktion.argTypes = paramTypes;
@@ -822,11 +819,7 @@ function Parser.type_check_method_call(expr: Node*) {
 	}
 
 	if(funktion.funktion.returnType.is_structural()) {
-		expr.funktion.argumentStackOffset = this.currentBlock.block.currentStackOffset += funktion.funktion.returnType.size_offset();
-
-		if(expr.funktion.argumentStackOffset > this.currentFunction.funktion.localVariableStackOffset) {
-			this.currentFunction.funktion.localVariableStackOffset = expr.funktion.argumentStackOffset;
-		}
+		expr.funktion.argumentStackOffset = temporaryOffset += funktion.funktion.returnType.size_offset();
 	}
 
 	expr.funktion.argTypes = paramTypes;
@@ -1776,6 +1769,8 @@ function Parser.type_check_return(stmt: Node*) {
 }
 
 function Parser.type_check_statement(stmt: Node*) {
+	temporaryOffset = 0;
+
 	if(stmt.type == NodeType::IF) {
 		this.type_check_if_statement(stmt);
 	}
@@ -1827,6 +1822,10 @@ function Parser.type_check_statement(stmt: Node*) {
 	else {
 		eputsln("Unreachable - type_check_statement");
 		exit(1);
+	}
+
+	if(temporaryOffset > this.currentFunction.funktion.temporaryStackOffset) {
+		this.currentFunction.funktion.temporaryStackOffset = temporaryOffset;
 	}
 }
 

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -821,6 +821,14 @@ function Parser.type_check_method_call(expr: Node*) {
 		}
 	}
 
+	if(funktion.funktion.returnType.is_structural()) {
+		expr.funktion.argumentStackOffset = this.currentBlock.block.currentStackOffset += funktion.funktion.returnType.size_offset();
+
+		if(expr.funktion.argumentStackOffset > this.currentFunction.funktion.localVariableStackOffset) {
+			this.currentFunction.funktion.localVariableStackOffset = expr.funktion.argumentStackOffset;
+		}
+	}
+
 	expr.funktion.argTypes = paramTypes;
 
 	expr.computedType = funktion.funktion.returnType;

--- a/tests/core.sh
+++ b/tests/core.sh
@@ -2702,3 +2702,310 @@ function main(): int {
 "
 
 echo " Done"
+
+echo -n "Pass Structs: "
+
+assert_stdout "56
+30
+12
+15" "
+import \"std/io.zpr\";
+
+struct Point {
+	x: int;
+	y: int;
+}
+
+function a(b: Point) {
+	b.x = 56;
+	b.y *= 2;
+
+	putd(b.x);
+	putln();
+	putd(b.y);
+	putln();
+}
+
+function main() {
+	var p: Point;
+	p.x = 12;
+	p.y = 15;
+
+	a(p);
+
+	putd(p.x);
+	putln();
+	putd(p.y);
+	putln();
+}
+"
+
+assert_stdout "Copying
+56
+30
+12
+15" "
+import \"std/io.zpr\";
+
+struct Point {
+	x: int;
+	y: int;
+}
+
+function Point.copy(other: Point*) {
+	putsln(\"Copying\");
+	this.x = other.x;
+	this.y = other.y;
+}
+
+function a(b: Point) {
+	b.x = 56;
+	b.y *= 2;
+
+	putd(b.x);
+	putln();
+	putd(b.y);
+	putln();
+}
+
+function main() {
+	var p: Point;
+	p.x = 12;
+	p.y = 15;
+
+	a(p);
+
+	putd(p.x);
+	putln();
+	putd(p.y);
+	putln();
+}
+"
+
+assert_stdout "56
+30
+12
+15" "
+import \"std/io.zpr\";
+
+struct Point {
+	x: int;
+	y: int;
+}
+
+function a(a1: int, a2: int, a3: int, a4: int, a5: int, a6: int, b: Point) {
+	b.x = 56;
+	b.y *= 2;
+
+	putd(b.x);
+	putln();
+	putd(b.y);
+	putln();
+}
+
+function main() {
+	var p: Point;
+	p.x = 12;
+	p.y = 15;
+
+	a(1, 2, 3, 4, 5, 6, p);
+
+	putd(p.x);
+	putln();
+	putd(p.y);
+	putln();
+}
+"
+
+assert_stdout "Copying
+56
+30
+12
+15" "
+import \"std/io.zpr\";
+
+struct Point {
+	x: int;
+	y: int;
+}
+
+function Point.copy(other: Point*) {
+	putsln(\"Copying\");
+	this.x = other.x;
+	this.y = other.y;
+}
+
+function a(a1: int, a2: int, a3: int, a4: int, a5: int, a6: int, b: Point) {
+	b.x = 56;
+	b.y *= 2;
+
+	putd(b.x);
+	putln();
+	putd(b.y);
+	putln();
+}
+
+function main() {
+	var p: Point;
+	p.x = 12;
+	p.y = 15;
+
+	a(1, 2, 3, 4, 5, 6, p);
+
+	putd(p.x);
+	putln();
+	putd(p.y);
+	putln();
+}
+"
+
+assert_stdout "12
+15" "
+import \"std/io.zpr\";
+
+struct Point {
+	x: int;
+	y: int;
+}
+
+function a(): Point {
+	var p: Point;
+	p.x = 12;
+	p.y = 15;
+	
+	return p;
+}
+
+function b(p: Point) {
+	putd(p.x);
+	putln();
+	putd(p.y);
+	putln();
+}
+
+function main() {
+	b(a());
+}
+"
+
+assert_stdout "12
+15" "
+import \"std/io.zpr\";
+
+struct Point {
+	x: int;
+	y: int;
+}
+
+struct X { y: any; }
+
+function X.a(): Point {
+	var p: Point;
+	p.x = 12;
+	p.y = 15;
+	
+	return p;
+}
+
+function b(p: Point) {
+	putd(p.x);
+	putln();
+	putd(p.y);
+	putln();
+}
+
+function main() {
+	var x: X;
+	b(x.a());
+}
+"
+
+assert_stdout "Copied!
+Copied!
+12
+15" "
+import \"std/io.zpr\";
+
+struct Point {
+	x: int;
+	y: int;
+}
+
+function Point.copy(other: Point*) {
+	putsln(\"Copied!\");
+	this.x = other.x;
+	this.y = other.y;
+}
+
+function a(): Point {
+	var p: Point;
+	p.x = 12;
+	p.y = 15;
+	
+	// Copy here
+	return p;
+}
+
+function b(p: Point) {
+	// Copy here
+	putd(p.x);
+	putln();
+	putd(p.y);
+	putln();
+}
+
+function main() {
+	b(a());
+}
+"
+
+assert_stdout "Copied!
+Deconstructed!
+Copied!
+12
+15
+Deconstructed!
+Deconstructed!" "
+import \"std/io.zpr\";
+
+struct Point {
+	x: int;
+	y: int;
+}
+
+function Point.copy(other: Point*) {
+	putsln(\"Copied!\");
+	this.x = other.x;
+	this.y = other.y;
+}
+
+function Point.deconstructor() {
+	putsln(\"Deconstructed!\");
+}
+
+function a(): Point {
+	var p: Point;
+	p.x = 12;
+	p.y = 15;
+	
+	// Copy here
+	return p;
+	// Deconstruct here
+}
+
+function b(p: Point) {
+	// Copy here
+	putd(p.x);
+	putln();
+	putd(p.y);
+	putln();
+	// Deconstruct here
+}
+
+function main() {
+	b(a());
+	// Deconstruct here
+}
+"
+
+echo " Done"


### PR DESCRIPTION
# Description
Allows functions (and methods) to both accept structures as arguments as well as returning them.
For example, this change permits the following:
```zephyr
function update(before: Point): Point { ... }
```
Where the closest form before this change would be:
```zephyr
function update(before: Point*): Point* { ... }
```
Structures are copied on passing or on returning so as to be deconstructed correctly. For example, the points at which structures are copied and deconstructed is shown here:
```zephyr
import "std/io.zpr";

struct Point {
	x: int;
	y: int;
}

function Point.copy(other: Point*) {
	putsln("Copied!");
	this.x = other.x;
	this.y = other.y;
}

function Point.deconstructor() {
	putsln("Deconstructed!");
}

function a(): Point {
	var p: Point; (1)
	p.x = 12;
	p.y = 15;
	
	// Copy here (1)
	return p;
	// Deconstruct here (1)
}

function b(p: Point) { // argument (2)
	// Copy here (2)
	putd(p.x);
	putln();
	putd(p.y);
	putln();
	// Deconstruct here (2)
}

function main() {
	b(a()); // create temporary (3)
	// Deconstruct here (3)
}
```
# Related Issues
Closes #20 