### PR TITLE
Compiler Memory Refactor

### DIFF
--- a/bootstrap/bootstrap_x86_64_linux.yasm
+++ b/bootstrap/bootstrap_x86_64_linux.yasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aad103b8759abc727140eabdeadcd7218041e9b69ada8739dba145186d624c7f
-size 924866
+oid sha256:88f3358b1be5baa43ca48e65025451ce02099804e8e1c65d0b8d6a22b1399d98
+size 964494

--- a/examples/cat.zpr
+++ b/examples/cat.zpr
@@ -20,11 +20,13 @@ function main(argc: int, argv: i8**): int {
 		}
 		var text = file.slurp(null);
 		file.close();
+		delete file;
 		
 		puts(filename);
 		putsln(":");
 
 		putsln(text);
+		delete text;
 	}
 
 	return 0;

--- a/examples/gol.zpr
+++ b/examples/gol.zpr
@@ -7,34 +7,34 @@ const COLUMNS = 20;
 
 enum State {
 	DEAD,
-	LIVE
+	ALIVE
 }
 
 function row_col_idx(row: int, col: int): int {
 	return col * ROWS + row;
 }
 
-function cell_is_live(row: int, col: int, board: i8*): bool {
-	return board[row_col_idx(row, col)] == State::LIVE;
+function cell_is_alive(row: int, col: int, board: i8*): bool {
+	return board[row_col_idx(row, col)] == State::ALIVE;
 }
 
 function count_neighbours(row: int, col: int, board: i8*): int {
 	var neighbours = 0;
 	if(row != 0) {
-		neighbours += cell_is_live(row - 1, col, board);
-		if(col != 0) neighbours += cell_is_live(row - 1, col - 1, board);
-		if(col != COLUMNS - 1) neighbours += cell_is_live(row - 1, col + 1, board);
+		neighbours += cell_is_alive(row - 1, col, board);
+		if(col != 0) neighbours += cell_is_alive(row - 1, col - 1, board);
+		if(col != COLUMNS - 1) neighbours += cell_is_alive(row - 1, col + 1, board);
 	}
 	if(row != ROWS - 1) {
-		neighbours += cell_is_live(row + 1, col, board);
-		if(col != 0) neighbours += cell_is_live(row + 1, col - 1, board);
-		if(col != COLUMNS - 1) neighbours += cell_is_live(row + 1, col + 1, board);
+		neighbours += cell_is_alive(row + 1, col, board);
+		if(col != 0) neighbours += cell_is_alive(row + 1, col - 1, board);
+		if(col != COLUMNS - 1) neighbours += cell_is_alive(row + 1, col + 1, board);
 	}
 	if(col != 0) {
-		neighbours += cell_is_live(row, col - 1, board);
+		neighbours += cell_is_alive(row, col - 1, board);
 	}
 	if(col != COLUMNS - 1) {
-		neighbours += cell_is_live(row, col + 1, board);
+		neighbours += cell_is_alive(row, col + 1, board);
 	}
 
 	return neighbours;
@@ -45,12 +45,12 @@ function poll_new_state(row: int, col: int, board: i8*, scratchBoard: i8*) {
 
 	var idx = row_col_idx(row, col);
 
-	if(cell_is_live(row, col, board)) {
+	if(cell_is_alive(row, col, board)) {
 		if(liveNeighbours < 2) {
 			scratchBoard[idx] = State::DEAD;
 		}
 		else if(liveNeighbours == 2 || liveNeighbours == 3) {
-			scratchBoard[idx] = State::LIVE;
+			scratchBoard[idx] = State::ALIVE;
 		}
 		else {
 			scratchBoard[idx] = State::DEAD;
@@ -58,7 +58,7 @@ function poll_new_state(row: int, col: int, board: i8*, scratchBoard: i8*) {
 	}
 	else {
 		if(liveNeighbours == 3) {
-			scratchBoard[idx] = State::LIVE;
+			scratchBoard[idx] = State::ALIVE;
 		}
 	}
 }
@@ -85,7 +85,7 @@ function swap_boards(board: i8*, scratchBoard: i8*) {
 function print_board(board: i8*) {
 	for(var row = 0; row < ROWS; ++row) {
 		for(var col = 0; col < COLUMNS; ++col) {
-			putc(cell_is_live(row, col, board) ? '#' : ' ');
+			putc(cell_is_alive(row, col, board) ? '#' : ' ');
 		}
 		putln();
 	}
@@ -97,17 +97,17 @@ function move_cursor_start() {
 }
 
 function set_blinker(board: i8*) {
-	board[row_col_idx(5, 5)] = State::LIVE;
-	board[row_col_idx(6, 5)] = State::LIVE;
-	board[row_col_idx(7, 5)] = State::LIVE;
+	board[row_col_idx(5, 5)] = State::ALIVE;
+	board[row_col_idx(6, 5)] = State::ALIVE;
+	board[row_col_idx(7, 5)] = State::ALIVE;
 }
 
 function set_glider(board: i8*) {
-	board[row_col_idx(2, 0)] = State::LIVE;
-	board[row_col_idx(3, 1)] = State::LIVE;
-	board[row_col_idx(1, 2)] = State::LIVE;
-	board[row_col_idx(2, 2)] = State::LIVE;
-	board[row_col_idx(3, 2)] = State::LIVE;
+	board[row_col_idx(2, 0)] = State::ALIVE;
+	board[row_col_idx(3, 1)] = State::ALIVE;
+	board[row_col_idx(1, 2)] = State::ALIVE;
+	board[row_col_idx(2, 2)] = State::ALIVE;
+	board[row_col_idx(3, 2)] = State::ALIVE;
 }
 
 function main(): int {

--- a/examples/mandelbrot.zpr
+++ b/examples/mandelbrot.zpr
@@ -40,7 +40,7 @@ function main(argc: int, argv: i8**): int {
 	var pixelWidth = (cxmax-cxmin)/ixmax;
 	var pixelHeight = (cymax-cymin)/iymax;
 
-	var img = std::image::new_ppm_img(ixmax, iymax);
+	var img: std::image::PPMImage(ixmax, iymax);
 
 	for(var iy = 0; iy < iymax; ++iy) {
 		var cy = cymin + iy*pixelHeight;

--- a/examples/server.zpr
+++ b/examples/server.zpr
@@ -40,6 +40,7 @@ function read_content(path: i8*): i8* {
 	}
 	var text = file.slurp(null);
 	file.close();
+	delete file;
 	return text;
 }
 

--- a/examples/server.zpr
+++ b/examples/server.zpr
@@ -12,21 +12,20 @@ const PORT = 8080;
 
 function respond(body: i8*): i8* {
 	var start = "HTTP/1.1 200 OK";
-	var newline: i8[3] = [13, 10, 0];
 
 	// Calculate size
 	var length = strlen(body);
 	var lenBuf: i8[20];
 	itoa(length, lenBuf, 10);
 
-	var response = malloc(256 + length);
+	var response = new i8[256 + length];
 
-	memcpy(response, start, strlen(start) + 1);                     strcat(response, newline);
-	strcat(response, "Server: Zephyr PL Server/0.1.1");             strcat(response, newline);
-	strcat(response, "Connection: Closed");                         strcat(response, newline);
-	strcat(response, "Content-Type: text/html");                    strcat(response, newline);
-	strcat(response, "Content-Length: "); strcat(response, lenBuf); strcat(response, newline);
-	strcat(response, newline);
+	memcpy(response, start, strlen(start) + 1);                     strcat(response, "\r\n");
+	strcat(response, "Server: Zephyr PL Server/0.1.1");             strcat(response, "\r\n");
+	strcat(response, "Connection: Closed");                         strcat(response, "\r\n");
+	strcat(response, "Content-Type: text/html");                    strcat(response, "\r\n");
+	strcat(response, "Content-Length: "); strcat(response, lenBuf); strcat(response, "\r\n");
+	strcat(response, "\r\n");
 	strcat(response, body);
 
 	return response;
@@ -122,6 +121,8 @@ function main(): int {
 
 		close(newSocket);
 	}
+
+	delete[] response;
 
 	close(serverFd);
 	return 0;

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -361,7 +361,7 @@ function File.put_name(name: Name*) {
 
 function Name.to_string(): i8* {
 	var namespaceLength = 0;
-	var parts = new_vector();
+	var parts: Vector;
 
 	if(this.namespaceName != null) {
 		for(var i = 0; i < this.namespaceName.parts.size; ++i) {
@@ -391,14 +391,12 @@ function Name.to_string(): i8* {
 		free(part);
 	}
 
-	free(parts);
-
 	return str;
 }
 
 function new_namespace(name: Token*, parent: Namespace*): Namespace* {
-	var namespaceName: Namespace* = malloc(sizeof(Namespace));
-	namespaceName.parts = new_vector();
+	var namespaceName = new Namespace;
+	namespaceName.parts = new Vector;
 
 	if(parent != null) {
 		for(var i = 0; i < parent.parts.size; ++i) {
@@ -444,7 +442,7 @@ function Type.add_method(method: Node*) {
 		list.push(method);
 	}
 	else {
-		list = new_vector();
+		list = new Vector();
 		list.push(method);
 		this.methods.set(nameStr, list);
 	}

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -302,7 +302,10 @@ function free_nodes() {
 	delete __allNodes;
 }
 
-function Node.constructor() {
+function Node.constructor(type: int, position: Token*) {
+	this.type = type;
+	this.position = position;
+
 	if(__allNodes == null) {
 		__allNodes = new Vector;
 	}
@@ -322,18 +325,27 @@ function Node.deconstructor() {
 			delete this.literal.az.string.chars;
 		}
 		NodeType::CALL -> {
+			this.funktion.name.deconstructor();
 			delete this.funktion.arguments;
 			delete this.funktion.argTypes;
 		}
 		NodeType::CALL_METHOD -> {
+			this.funktion.name.deconstructor();
 			delete this.funktion.arguments;
 			delete this.funktion.argTypes;
 		}
 		NodeType::DEFINE_VAR, NodeType::DEFINE_GLOBAL_VAR -> {
+			this.variable.name.deconstructor();
 			if(this.variable.arguments != null)
 				delete this.variable.arguments;
 			if(this.variable.argTypes != null)
 				delete this.variable.argTypes;
+		}
+		NodeType::ACCESS_VAR, NodeType::ACCESS_GLOBAL_VAR -> {
+			this.variable.name.deconstructor();
+		}
+		NodeType::DEFINE_CONST -> {
+			this.constant.name.deconstructor();
 		}
 		NodeType::ARRAY_INIT -> {
 			delete this.block.children;
@@ -351,6 +363,7 @@ function Node.deconstructor() {
 			delete this.branch.values;
 		}
 		NodeType::FUNCTION -> {
+			this.funktion.name.deconstructor();
 			delete this.funktion.arguments;
 			if(this.funktion.argTypes != null)
 				delete this.funktion.argTypes;
@@ -381,6 +394,16 @@ struct Name {
 function Name.init(namespaceName: Namespace*, name: Token*) {
 	this.namespaceName = namespaceName;
 	this.name = name;
+}
+
+function Name.deconstructor() {
+	if(this.namespaceName != null)
+		delete this.namespaceName;
+}
+
+function Namespace.deconstructor() {
+	if(this.parts != null)
+		delete this.parts;
 }
 
 function Name.fput(fd: int) {
@@ -471,19 +494,16 @@ function Name.to_string(): i8* {
 	return str;
 }
 
-function new_namespace(name: Token*, parent: Namespace*): Namespace* {
-	var namespaceName = new Namespace;
-	namespaceName.parts = new Vector;
+function Namespace.constructor(name: Token*, parent: Namespace*) {
+	this.parts = new Vector;
 
 	if(parent != null) {
 		for(var i = 0; i < parent.parts.size; ++i) {
-			namespaceName.parts.push(parent.parts.at(i));
+			this.parts.push(parent.parts.at(i));
 		}
 	}
 
-	if(name != null) namespaceName.parts.push(name);
-
-	return namespaceName;
+	if(name != null) this.parts.push(name);
 }
 
 function Namespace.fput(fd: int) {
@@ -523,6 +543,7 @@ function Type.add_method(method: Node*) {
 		list.push(method);
 		this.methods.set(nameStr, list);
 	}
+	delete nameStr;
 }
 
 function Type.get_method(name: Name*, found: bool*): Vector* {
@@ -530,6 +551,7 @@ function Type.get_method(name: Name*, found: bool*): Vector* {
 
 	var list = this.methods.get(nameStr, found) as Vector*;
 
+	delete nameStr;
 	return list;
 }
 

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -372,7 +372,7 @@ function Name.to_string(): i8* {
 		}
 	}
 
-	var str: i8* = malloc(namespaceLength + this.name.length + 1);
+	var str = new i8[namespaceLength + this.name.length + 1];
 	str[0] = 0;
 
 	for(var i = 0; i < parts.size; ++i) {
@@ -507,7 +507,7 @@ function __type_to_string(type: Type*, quoted: bool): i8* {
 	if(aliasLength == 0) {
 		var quotesLength = quoted ? 2 : 0;
 
-		str = malloc(quoted + strlen(baseType) + type.indirection + aliasLength + 1);
+		str = new i8[quoted + strlen(baseType) + type.indirection + aliasLength + 1];
 		if(quoted) {
 			str[0] = 39; // '
 			strcpy(&str[1], baseType);
@@ -523,7 +523,7 @@ function __type_to_string(type: Type*, quoted: bool): i8* {
 	else {
 		var quotesLength = quoted ? 4 : 2;
 
-		str = malloc(strlen(baseType) + quotesLength + aliasLength + 1);
+		str = new i8[strlen(baseType) + quotesLength + aliasLength + 1];
 
 		if(quoted) {
 			str[0] = 39;
@@ -537,7 +537,7 @@ function __type_to_string(type: Type*, quoted: bool): i8* {
 		strcat(str, " (alias of '");
 		strcat(str, baseType);
 		strcat(str, "')");
-		free(aliasName);
+		delete aliasName;
 	}
 
 	return str;

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -292,6 +292,83 @@ struct Node {
 	};
 }
 
+var __allNodes: Vector* = null;
+
+function free_nodes() {
+	if(__allNodes == null) return;
+	for(var i = 0; i < __allNodes.size; ++i) {
+		delete (__allNodes.at(i) as Node*);
+	}
+	delete __allNodes;
+}
+
+function Node.constructor() {
+	if(__allNodes == null) {
+		__allNodes = new Vector;
+	}
+	__allNodes.push(this);
+}
+
+function Node.deconstructor() {
+	if(this.temporaries != null) {
+		delete this.temporaries;
+	}
+	
+	when(this.type) {
+		NodeType::FLOAT_LITERAL -> {
+			delete this.literal.az.float.str;
+		}
+		NodeType::STRING -> {
+			delete this.literal.az.string.chars;
+		}
+		NodeType::CALL -> {
+			delete this.funktion.arguments;
+			delete this.funktion.argTypes;
+		}
+		NodeType::CALL_METHOD -> {
+			delete this.funktion.arguments;
+			delete this.funktion.argTypes;
+		}
+		NodeType::DEFINE_VAR, NodeType::DEFINE_GLOBAL_VAR -> {
+			if(this.variable.arguments != null)
+				delete this.variable.arguments;
+			if(this.variable.argTypes != null)
+				delete this.variable.argTypes;
+		}
+		NodeType::ARRAY_INIT -> {
+			delete this.block.children;
+		}
+		NodeType::NEW -> {
+			if(this.constructor.argTypes != null)
+				delete this.constructor.argTypes;
+			if(this.constructor.arguments != null)
+				delete this.constructor.arguments;
+		}
+		NodeType::WHEN -> {
+			delete this.vhen.branches;
+		}
+		NodeType::BRANCH -> {
+			delete this.branch.values;
+		}
+		NodeType::FUNCTION -> {
+			delete this.funktion.arguments;
+			if(this.funktion.argTypes != null)
+				delete this.funktion.argTypes;
+		}
+		NodeType::NAMESPACE -> {
+			delete this.nameSpace.name;
+		}
+		NodeType::BLOCK -> {
+			delete this.block.children;
+			if(this.block.variables != null)
+				delete this.block.variables;
+		}
+		NodeType::PROGRAM -> {
+			delete this.block.children;
+		}
+	}
+}
+
 struct Namespace {
 	parts: Vector*; // Vector*<Token*>
 }

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -384,11 +384,11 @@ function Name.to_string(): i8* {
 
 	var name = this.name.name_to_str();
 	strcat(str, name);
-	free(name);
+	delete name;
 
 	for(var i = 0; i < parts.size; ++i) {
 		var part = parts.at(i);
-		free(part);
+		delete part;
 	}
 
 	return str;

--- a/src/builtin.zpr
+++ b/src/builtin.zpr
@@ -5,13 +5,13 @@ var builtinFunctions: Vector*;
 
 function add_implicit_printu_function(): Node* {
 	var name = synthetic_token(TokenType::IDENTIFIER, "printu");
-	var funktion = new_node(NodeType::FUNCTION, name);
+	var funktion = new Node(NodeType::FUNCTION, name);
 	funktion.funktion.name.name = name;
 
 	funktion.funktion.arguments = new Vector();
 
 	var valTok = synthetic_token(TokenType::IDENTIFIER, "value");
-	var val = new_node(NodeType::DEFINE_VAR, valTok);
+	var val = new Node(NodeType::DEFINE_VAR, valTok);
 	val.variable.name.name = valTok;
 	val.variable.type = UINT_TYPE;
 	funktion.funktion.arguments.push(val);
@@ -25,12 +25,12 @@ function add_implicit_printu_function(): Node* {
 
 function add_implicit_syscall_function(sysName: i8*, argCount: int): Node* {
 	var name = synthetic_token(TokenType::IDENTIFIER, sysName);
-	var funktion = new_node(NodeType::FUNCTION, name);
+	var funktion = new Node(NodeType::FUNCTION, name);
 	funktion.funktion.name.name = name;
 	funktion.funktion.arguments = new Vector();
 
 	var nrTok = synthetic_token(TokenType::IDENTIFIER, "nr");
-	var nr = new_node(NodeType::DEFINE_VAR, nrTok);
+	var nr = new Node(NodeType::DEFINE_VAR, nrTok);
 	nr.variable.name.name = nrTok;
 	nr.variable.type = INT_TYPE;
 	
@@ -38,7 +38,7 @@ function add_implicit_syscall_function(sysName: i8*, argCount: int): Node* {
 
 	for(var i = 0; i < argCount; ++i) {
 		var argTok = synthetic_token(TokenType::IDENTIFIER, "arg");
-		var arg = new_node(NodeType::DEFINE_VAR, argTok);
+		var arg = new Node(NodeType::DEFINE_VAR, argTok);
 		arg.variable.name.name = argTok;
 		arg.variable.type = ANY_TYPE;
 

--- a/src/builtin.zpr
+++ b/src/builtin.zpr
@@ -8,7 +8,7 @@ function add_implicit_printu_function(): Node* {
 	var funktion = new_node(NodeType::FUNCTION, name);
 	funktion.funktion.name.name = name;
 
-	funktion.funktion.arguments = new_vector();
+	funktion.funktion.arguments = new Vector();
 
 	var valTok = synthetic_token(TokenType::IDENTIFIER, "value");
 	var val = new_node(NodeType::DEFINE_VAR, valTok);
@@ -27,7 +27,7 @@ function add_implicit_syscall_function(sysName: i8*, argCount: int): Node* {
 	var name = synthetic_token(TokenType::IDENTIFIER, sysName);
 	var funktion = new_node(NodeType::FUNCTION, name);
 	funktion.funktion.name.name = name;
-	funktion.funktion.arguments = new_vector();
+	funktion.funktion.arguments = new Vector();
 
 	var nrTok = synthetic_token(TokenType::IDENTIFIER, "nr");
 	var nr = new_node(NodeType::DEFINE_VAR, nrTok);
@@ -53,7 +53,7 @@ function add_implicit_syscall_function(sysName: i8*, argCount: int): Node* {
 }
 
 function parser_builtin_functions(): Vector* {
-	var functions = new_vector();
+	var functions = new Vector();
 
 	functions.push(add_implicit_printu_function());
 	functions.push(add_implicit_syscall_function("syscall0", 0));

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -681,10 +681,10 @@ function generate_assign(expr: Node*, out: File*) {
 		out.putsln("    mov rsi, rax");
 		out.putsln("    mov rax, QWORD [rsp]");
 
-		var args = new_vector();
+		var args: Vector;
 		args.push(expr.assignment.rhs.overload.rhsType);
 
-		generate_method_call(null, expr.assignment.rhs.overload.lhsType, Typecheck::get_name_from_overload(expr.assignment.rhs.overload.op), null, args, null, 0, out);
+		generate_method_call(null, expr.assignment.rhs.overload.lhsType, Typecheck::get_name_from_overload(expr.assignment.rhs.overload.op), null, &args, null, 0, out);
 		out.putsln("    pop rax");
 		return;
 	}
@@ -1103,14 +1103,14 @@ function generate_define_var(stmt: Node*, out: File*) {
 				var copyName: Name;
 				parser.bind_name(&copyName, copyTok);
 
-				var args = new_vector();
+				var args: Vector;
 				var typePtr = copy_type(stmt.variable.type);
 				typePtr.indirection = 1;
 				args.push(typePtr);
 
 				out.puts("    lea rdi, [rbp-"); out.putd(stmt.variable.stackOffset); out.putsln("]");
 				out.putsln("    mov rsi, rax");
-				out.puts("    call _M"); out.put_arguments(args);
+				out.puts("    call _M"); out.put_arguments(&args);
 				out.put_name(&stmt.variable.type.name); out.puts("_"); out.put_name(&copyName); out.putln();
 			}
 			else {
@@ -1239,7 +1239,7 @@ function generate_return(stmt: Node*, out: File*) {
 			var copyName: Name;
 			parser.bind_name(&copyName, copyTok);
 
-			var args = new_vector();
+			var args: Vector;
 			var typePtr = copy_type(stmt.ret.type);
 			typePtr.indirection = 1;
 			args.push(typePtr);
@@ -1247,7 +1247,7 @@ function generate_return(stmt: Node*, out: File*) {
 			out.putsln("    push rcx");
 			out.putsln("    mov rdi, rcx");
 			out.putsln("    mov rsi, rax");
-			out.puts("    call _M"); out.put_arguments(args);
+			out.puts("    call _M"); out.put_arguments(&args);
 			out.put_name(&stmt.ret.type.name); out.puts("_"); out.put_name(&copyName); out.putln();
 			out.putsln("    pop rax");
 		}
@@ -1429,14 +1429,14 @@ function generate_function(funktion: Node*, out: File*) {
 				var copyName: Name;
 				parser.bind_name(&copyName, copyTok);
 
-				var args = new_vector();
+				var args: Vector;
 				var typePtr = copy_type(arg.variable.type);
 				typePtr.indirection = 1;
 				args.push(typePtr);
 
 				out.putsln("    mov rdi, rcx");
 				out.putsln("    mov rsi, rax");
-				out.puts("    call _M"); out.put_arguments(args);
+				out.puts("    call _M"); out.put_arguments(&args);
 				out.put_name(&arg.variable.type.name); out.puts("_"); out.put_name(&copyName); out.putln();
 			}
 			else {
@@ -1593,14 +1593,14 @@ function Parser.generate_program(ast: Node*, out: File*) {
 					var copyName: Name;
 					parser.bind_name(&copyName, copyTok);
 
-					var args = new_vector();
+					var args: Vector;
 					var typePtr = copy_type(variable.variable.type);
 					typePtr.indirection = 1;
 					args.push(typePtr);
 
 					out.puts("    lea rdi, [_G"); out.put_name(&variable.variable.name); out.putsln("]");
 					out.putsln("    mov rsi, rax");
-					out.puts("    call _M"); out.put_arguments(args);
+					out.puts("    call _M"); out.put_arguments(&args);
 					out.put_name(&variable.variable.type.name); out.puts("_"); out.put_name(&copyName); out.putln();
 				}
 				else {

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -80,6 +80,12 @@ function Parser.dce_expression(expr: Node*) {
 				mallocFunc.funktion.dced = true;
 				this.dce_function(mallocFunc);
 			}
+			if(expr.constructor.arguments != null) {
+				for(var i = 0; i < expr.constructor.arguments.size; ++i) {
+					var arg: Node* = expr.constructor.arguments.at(i);
+					this.dce_expression(arg);
+				}
+			}
 			if(expr.constructor.shouldConstruct) {
 				var constructorTok = synthetic_token(TokenType::IDENTIFIER, "constructor");
 				var constructorName: Name;

--- a/src/dce.zpr
+++ b/src/dce.zpr
@@ -105,8 +105,8 @@ function Parser.dce_expression(expr: Node*) {
 				var constructorName: Name;
 				this.bind_name(&constructorName, constructorTok);
 
-				var argTypes = new_vector();
-				var constructor = expr.constructor.type.lookup_method_with_arguments(&constructorName, argTypes);
+				var argTypes: Vector;
+				var constructor = expr.constructor.type.lookup_method_with_arguments(&constructorName, &argTypes);
 				if(!constructor.funktion.dced) {
 					constructor.funktion.dced = true;
 					this.dce_function(constructor);
@@ -146,8 +146,8 @@ function Parser.dce_block(block: Node*) {
 		var deconstructorName: Name;
 		this.bind_name(&deconstructorName, deconstructorTok);
 
-		var argTypes = new_vector();
-		var deconstructor = variable.variable.type.lookup_method_with_arguments(&deconstructorName, argTypes);
+		var argTypes: Vector;
+		var deconstructor = variable.variable.type.lookup_method_with_arguments(&deconstructorName, &argTypes);
 
 		if(deconstructor != null && !deconstructor.funktion.dced) {
 			deconstructor.funktion.dced = true;
@@ -192,12 +192,12 @@ function Parser.dce_statement(stmt: Node*) {
 					var copyName: Name;
 					this.bind_name(&copyName, copyTok);
 
-					var args = new_vector();
+					var args: Vector;
 					var typePtr = copy_type(stmt.variable.type);
 					typePtr.indirection = 1;
 					args.push(typePtr);
 
-					var copy = stmt.variable.type.lookup_method_with_arguments(&copyName, args);
+					var copy = stmt.variable.type.lookup_method_with_arguments(&copyName, &args);
 					if(!copy.funktion.dced) {
 						this.dce_function(copy);
 					}
@@ -234,12 +234,12 @@ function Parser.dce_statement(stmt: Node*) {
 				var copyName: Name;
 				this.bind_name(&copyName, copyTok);
 
-				var args = new_vector();
+				var args: Vector;
 				var typePtr = copy_type(stmt.ret.type);
 				typePtr.indirection = 1;
 				args.push(typePtr);
 
-				var copy = stmt.ret.type.lookup_method_with_arguments(&copyName, args);
+				var copy = stmt.ret.type.lookup_method_with_arguments(&copyName, &args);
 
 				if(!copy.funktion.dced) {
 					this.dce_function(copy);
@@ -260,8 +260,8 @@ function Parser.dce_statement(stmt: Node*) {
 				var deconstructorName: Name;
 				this.bind_name(&deconstructorName, deconstructorTok);
 
-				var argTypes = new_vector();
-				var deconstructor = stmt.unary.computedType.lookup_method_with_arguments(&deconstructorName, argTypes);
+				var argTypes: Vector;
+				var deconstructor = stmt.unary.computedType.lookup_method_with_arguments(&deconstructorName, &argTypes);
 
 				if(deconstructor != null && !deconstructor.funktion.dced) {
 					deconstructor.funktion.dced = true;
@@ -288,8 +288,8 @@ function Parser.dce_statement(stmt: Node*) {
 				var deconstructorName: Name;
 				this.bind_name(&deconstructorName, deconstructorTok);
 
-				var argTypes = new_vector();
-				var deconstructor = stmt.unary.computedType.lookup_method_with_arguments(&deconstructorName, argTypes);
+				var argTypes: Vector;
+				var deconstructor = stmt.unary.computedType.lookup_method_with_arguments(&deconstructorName, &argTypes);
 
 				if(deconstructor != null && !deconstructor.funktion.dced) {
 					deconstructor.funktion.dced = true;
@@ -313,8 +313,8 @@ function Parser.dce_statement(stmt: Node*) {
 			var deconstructorName: Name;
 			this.bind_name(&deconstructorName, deconstructorTok);
 
-			var argTypes = new_vector();
-			var deconstructor = temp.computedType.lookup_method_with_arguments(&deconstructorName, argTypes);
+			var argTypes: Vector;
+			var deconstructor = temp.computedType.lookup_method_with_arguments(&deconstructorName, &argTypes);
 
 			if(deconstructor != null && !deconstructor.funktion.dced) {
 				deconstructor.funktion.dced = true;
@@ -333,12 +333,12 @@ function Parser.dce_function(funktion: Node*) {
 			var copyName: Name;
 			this.bind_name(&copyName, copyTok);
 
-			var args = new_vector();
+			var args: Vector;
 			var typePtr = copy_type(arg.variable.type);
 			typePtr.indirection = 1;
 			args.push(typePtr);
 
-			var copy = arg.variable.type.lookup_method_with_arguments(&copyName, args);
+			var copy = arg.variable.type.lookup_method_with_arguments(&copyName, &args);
 			if(!copy.funktion.dced) {
 				this.dce_function(copy);
 			}
@@ -390,12 +390,12 @@ function Parser.dce() {
 				var copyName: Name;
 				this.bind_name(&copyName, copyTok);
 
-				var args = new_vector();
+				var args: Vector;
 				var typePtr = copy_type(gvar.variable.type);
 				typePtr.indirection = 1;
 				args.push(typePtr);
 
-				var copy = gvar.variable.type.lookup_method_with_arguments(&copyName, args);
+				var copy = gvar.variable.type.lookup_method_with_arguments(&copyName, &args);
 				if(!copy.funktion.dced) {
 					this.dce_function(copy);
 				}

--- a/src/lexer.zpr
+++ b/src/lexer.zpr
@@ -12,7 +12,7 @@ struct Lexer {
 }
 
 function new_lexer(filename: i8*, source: i8*): Lexer* {
-	var lexer: Lexer* = malloc(sizeof(Lexer));
+	var lexer = new Lexer;
 	lexer.start = source;
 	lexer.current = source;
 	lexer.line = 1;
@@ -50,7 +50,7 @@ function Lexer.match(expected: i8): int {
 }
 
 function Lexer.make_token(type: int): Token* {
-	var token: Token* = malloc(sizeof(Token));
+	var token = new Token;
 	token.type = type;
 	token.start = this.start;
 	token.length = (this.current as int) - (this.start as int);
@@ -60,7 +60,7 @@ function Lexer.make_token(type: int): Token* {
 }
 
 function Lexer.error_token(message: i8*): Token* {
-	var token: Token* = malloc(sizeof(Token));
+	var token = new Token;
 	token.type = TokenType::ERROR;
 	token.start = message;
 	token.length = strlen(message);

--- a/src/lexer.zpr
+++ b/src/lexer.zpr
@@ -11,14 +11,11 @@ struct Lexer {
 	filename: i8*;
 }
 
-function new_lexer(filename: i8*, source: i8*): Lexer* {
-	var lexer = new Lexer;
-	lexer.start = source;
-	lexer.current = source;
-	lexer.line = 1;
-	lexer.filename = filename;
-
-	return lexer;
+function Lexer.constructor(filename: i8*, source: i8*) {
+	this.start = source;
+	this.current = source;
+	this.line = 1;
+	this.filename = filename;
 }
 
 function Lexer.is_at_end(): int {

--- a/src/main.zpr
+++ b/src/main.zpr
@@ -123,6 +123,10 @@ function main(argc: int, argv: i8**): int {
 	if(m_cliSource == null)
 		delete source;
 
+	free_tokens();
+	free_types();
+	free_nodes();
+
 	var objectFile: i8[1024];
 	strcpy(objectFile, m_outFile);
 	strcat(objectFile, ".o");

--- a/src/main.zpr
+++ b/src/main.zpr
@@ -116,6 +116,7 @@ function main(argc: int, argv: i8**): int {
 	var out = fopen(asmFile, 'w');
 	parser.generate_program(ast, out);
 	out.close();
+	delete out;
 
 	// Source was read from a file - free it
 	// If it's from the CLI do nothing

--- a/src/main.zpr
+++ b/src/main.zpr
@@ -121,7 +121,7 @@ function main(argc: int, argv: i8**): int {
 	// Source was read from a file - free it
 	// If it's from the CLI do nothing
 	if(m_cliSource == null)
-		free(source);
+		delete source;
 
 	var objectFile: i8[1024];
 	strcpy(objectFile, m_outFile);

--- a/src/main.zpr
+++ b/src/main.zpr
@@ -90,11 +90,11 @@ function main(argc: int, argv: i8**): int {
 		sourceFile.close();
 	}
 
-	var lexer = new_lexer(m_filepath == null ? "cli" : m_filepath, source);
+	var lexer = new Lexer(m_filepath == null ? "cli" : m_filepath, source);
 
 	build_types();
 
-	var parser = new_parser(lexer);
+	var parser = new Parser(lexer);
 
 	var ast = parser.parse_program();
 
@@ -126,6 +126,10 @@ function main(argc: int, argv: i8**): int {
 	free_tokens();
 	free_types();
 	free_nodes();
+	parser.free_open_files();
+
+	delete parser;
+	delete lexer;
 
 	var objectFile: i8[1024];
 	strcpy(objectFile, m_outFile);

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -34,30 +34,45 @@ struct Parser {
 	panic: int;
 }
 
-function new_parser(lexer: Lexer*): Parser* {
-	var parser = new Parser;
-	parser.lexer = lexer;
-	parser.functions = new std::map::HashMap();
-	parser.globalVars = new Vector();
-	parser.strings = new Vector();
-	parser.floats = new Vector();
-	parser.definedTypes = new Vector();
-	parser.lexerStack = new Vector();
-	parser.openedFiles =  new Vector();
-	parser.constants = new Vector();
-	parser.namespaceStack = new Vector();
-	return parser;
+function Parser.constructor(lexer: Lexer*) {
+	this.lexer = lexer;
+	this.functions = new std::map::HashMap();
+	this.globalVars = new Vector();
+	this.strings = new Vector();
+	this.floats = new Vector();
+	this.definedTypes = new Vector();
+	this.lexerStack = new Vector();
+	this.openedFiles =  new Vector();
+	this.constants = new Vector();
+	this.namespaceStack = new Vector();
 }
 
-function new_node(type: int, position: Token*): Node* {
-	var node: Node* = new Node;
-	node.type = type;
-	node.position = position;
-	return node;
+function Parser.deconstructor() {
+	delete this.globalVars;
+	delete this.strings;
+	delete this.floats;
+	delete this.definedTypes;
+	delete this.lexerStack;
+	delete this.constants;
+	delete this.namespaceStack;
+
+	for(var i = 0; i < this.functions.capacity; ++i) {
+		var item = this.functions.items[i];
+		if(item.key == null) continue;
+		var vec = item.value as Vector*;
+		delete vec;
+	}
+	delete this.functions;
 }
 
 function Node.add_child(child: Node*) {
 	this.block.children.push(child);
+}
+
+function Parser.free_open_files() {
+	for(var i = 0; i < this.openedFiles.size; ++i) {
+		delete[] this.openedFiles.at(i) as i8*;
+	}
 }
 
 function Parser.namespace_name(name: Name*, token: Token*) {
@@ -96,12 +111,15 @@ function Parser.add_function(funktion: Node*) {
 		list.push(funktion);
 		this.functions.set(nameStr, list);
 	}
+	delete nameStr;
 }
 
 function Parser.get_function(name: Name*, found: bool*): Vector* {
 	var nameStr = name.to_string();
 
 	var list = this.functions.get(nameStr, found) as Vector*;
+
+	delete nameStr;
 
 	return list;
 }
@@ -251,7 +269,7 @@ function Parser.parse_type_no_array(): Type* {
 
 			var name = this.previous;
 
-			var nameSpace = new_namespace(null, null);
+			var nameSpace = new Namespace(null, null);
 			nameSpace.parts = new Vector();
 
 			while(this.match(TokenType::COLON_COLON)) {
@@ -403,7 +421,7 @@ function Parser.parse_constant(): int {
 }
 
 function Parser.parse_call(name: Token*): Node* {
-	var call = new_node(NodeType::CALL, name);
+	var call = new Node(NodeType::CALL, name);
 	this.bind_name(&call.funktion.name, name);
 	call.funktion.arguments = new Vector();
 
@@ -427,7 +445,7 @@ function Parser.parse_call(name: Token*): Node* {
 function Parser.parse_identifier(): Node* {
 	var name = this.previous;
 
-	var nameSpace = new_namespace(null, null);
+	var nameSpace = new Namespace(null, null);
 	nameSpace.parts = new Vector();
 
 	while(this.match(TokenType::COLON_COLON)) {
@@ -441,7 +459,7 @@ function Parser.parse_identifier(): Node* {
 		return call;
 	}
 
-	var access = new_node(NodeType::ACCESS_VAR, name);
+	var access = new Node(NodeType::ACCESS_VAR, name);
 	this.bind_name(&access.variable.name, name);
 	if(nameSpace.parts.size > 0) bind_to_namespace(&access.variable.name, nameSpace);
 	access.lvalue = LValue::LOCAL;
@@ -452,7 +470,7 @@ function Parser.parse_new(): Node* {
 	var keyword = this.previous;
 	var type = this.parse_type_no_array();
 
-	var node = new_node(NodeType::NEW, keyword);
+	var node = new Node(NodeType::NEW, keyword);
 	node.constructor.type = type;
 	node.constructor.arguments = new Vector();
 
@@ -483,7 +501,7 @@ function Parser.parse_value(): Node* {
 		var literal = this.previous;
 		if(this.error) return null;
 
-		var literalNode = new_node(NodeType::INT_LITERAL, literal);
+		var literalNode = new Node(NodeType::INT_LITERAL, literal);
 		literalNode.literal.type = INT_TYPE;
 		literalNode.literal.az.integer = atoi(literal.start);
 
@@ -493,7 +511,7 @@ function Parser.parse_value(): Node* {
 		var literal = this.previous;
 		if(this.error) return null;
 
-		var literalNode = new_node(NodeType::UINT_LITERAL, literal);
+		var literalNode = new Node(NodeType::UINT_LITERAL, literal);
 		literalNode.literal.type = UINT_TYPE;
 		literalNode.literal.az.uinteger = atoui(literal.start);
 
@@ -503,7 +521,7 @@ function Parser.parse_value(): Node* {
 		var literal = this.previous;
 		if(this.error) return null;
 
-		var literalNode = new_node(NodeType::CHAR_LITERAL, literal);
+		var literalNode = new Node(NodeType::CHAR_LITERAL, literal);
 		literalNode.literal.type = I8_TYPE;
 		literalNode.literal.az.integer = this.escape_character(literal);
 
@@ -513,7 +531,7 @@ function Parser.parse_value(): Node* {
 		var literal = this.previous;
 		if(this.error) return null;
 
-		var literalNode = new_node(NodeType::FLOAT_LITERAL, literal);
+		var literalNode = new Node(NodeType::FLOAT_LITERAL, literal);
 		literalNode.literal.type = F64_TYPE;
 
 		var str = new i8[literal.length + 1];
@@ -530,7 +548,7 @@ function Parser.parse_value(): Node* {
 		var literal = this.previous;
 		if(this.error) return null;
 
-		var literalNode = new_node(NodeType::STRING, literal);
+		var literalNode = new Node(NodeType::STRING, literal);
 		literalNode.literal.type = STR_TYPE;
 
 		var buf = new i8[literal.length - 2 + 1];
@@ -554,7 +572,7 @@ function Parser.parse_value(): Node* {
 		return this.parse_identifier();
 	}
 	else if(this.match(TokenType::SIZEOF)) {
-		var expr = new_node(NodeType::SIZEOF, this.previous);
+		var expr = new Node(NodeType::SIZEOF, this.previous);
 		this.consume(TokenType::LEFT_PAREN, "Expected '(' after sizeof");
 		var type = this.parse_type();
 		this.consume(TokenType::RIGHT_PAREN, "Expected ')' after sizeof type");
@@ -585,7 +603,7 @@ function Parser.parse_member_access(): Node* {
 
 			this.consume(TokenType::RIGHT_SQBR, "Expected ']' after subscript index");
 
-			var subscript = new_node(NodeType::ACCESS_SUBSCRIPT, op);
+			var subscript = new Node(NodeType::ACCESS_SUBSCRIPT, op);
 			subscript.binary.lhs = left;
 			subscript.binary.rhs = right;
 			subscript.lvalue = LValue::SUBSCRIPT;
@@ -594,7 +612,7 @@ function Parser.parse_member_access(): Node* {
 		else if(op.type == TokenType::INCREMENT || op.type == TokenType::DECREMENT) {
 			var type = op.type == TokenType::INCREMENT ? NodeType::POST_INCREMENT : NodeType::POST_DECREMENT;
 
-			var postfix = new_node(type, op);
+			var postfix = new Node(type, op);
 			postfix.unary = left;
 			left = postfix;
 			break;
@@ -611,7 +629,7 @@ function Parser.parse_member_access(): Node* {
 				left = call;
 			}
 			else {
-				var member = new_node(NodeType::ACCESS_MEMBER, op);
+				var member = new Node(NodeType::ACCESS_MEMBER, op);
 				member.member.name = memberName;
 				member.member.parent = left;
 				member.lvalue = LValue::MEMBER;
@@ -627,35 +645,35 @@ function Parser.parse_unary(): Node* {
 	if(this.match(TokenType::TILDE)) {
 		var op = this.previous;
 		var expr = this.parse_unary();
-		var bwnot = new_node(NodeType::BWNOT, op);
+		var bwnot = new Node(NodeType::BWNOT, op);
 		bwnot.unary = expr;
 		return bwnot;
 	}
 	else if(this.match(TokenType::MINUS)) {
 		var op = this.previous;
 		var expr = this.parse_unary();
-		var neg = new_node(NodeType::NEG, op);
+		var neg = new Node(NodeType::NEG, op);
 		neg.unary = expr;
 		return neg;
 	}
 	else if(this.match(TokenType::BANG)) {
 		var op = this.previous;
 		var expr = this.parse_unary();
-		var not = new_node(NodeType::NOT, op);
+		var not = new Node(NodeType::NOT, op);
 		not.unary = expr;
 		return not;
 	}
 	else if(this.match(TokenType::AMP)) {
 		var op = this.previous;
 		var expr = this.parse_unary();
-		var addrOf = new_node(NodeType::ADDROF, op);
+		var addrOf = new Node(NodeType::ADDROF, op);
 		addrOf.unary = expr;
 		return addrOf;
 	}
 	else if(this.match(TokenType::STAR)) {
 		var op = this.previous;
 		var expr = this.parse_unary();
-		var deref = new_node(NodeType::DEREF, op);
+		var deref = new Node(NodeType::DEREF, op);
 		deref.unary = expr;
 		deref.lvalue = LValue::DEREF;
 		return deref;
@@ -663,14 +681,14 @@ function Parser.parse_unary(): Node* {
 	else if(this.match(TokenType::INCREMENT)) {
 		var op = this.previous;
 		var expr = this.parse_unary();
-		var increment = new_node(NodeType::PRE_INCREMENT, op);
+		var increment = new Node(NodeType::PRE_INCREMENT, op);
 		increment.unary = expr;
 		return increment;
 	}
 	else if(this.match(TokenType::DECREMENT)) {
 		var op = this.previous;
 		var expr = this.parse_unary();
-		var decrement = new_node(NodeType::PRE_DECREMENT, op);
+		var decrement = new Node(NodeType::PRE_DECREMENT, op);
 		decrement.unary = expr;
 		return decrement;
 	}
@@ -685,7 +703,7 @@ function Parser.parse_as_cast(): Node* {
 		var op = this.previous;
 		var castTo = this.parse_type();
 
-		var cast = new_node(NodeType::CAST, op);
+		var cast = new Node(NodeType::CAST, op);
 		cast.unary = left;
 		cast.computedType = castTo;
 		left = cast;
@@ -707,7 +725,7 @@ function Parser.parse_term(): Node* {
 		else if(op.type == TokenType::SLASH) type = NodeType::DIV;
 		else if(op.type == TokenType::PERCENT) type = NodeType::MOD;
 
-		var binary = new_node(type, op);
+		var binary = new Node(type, op);
 		binary.binary.lhs = left;
 		binary.binary.rhs = right;
 		left = binary;
@@ -728,7 +746,7 @@ function Parser.parse_arithmetic(): Node* {
 		if(op.type == TokenType::PLUS) type = NodeType::ADD;
 		else if(op.type == TokenType::MINUS) type = NodeType::SUB;
 
-		var binary = new_node(type, op);
+		var binary = new Node(type, op);
 		binary.binary.lhs = left;
 		binary.binary.rhs = right;
 		left = binary;
@@ -749,7 +767,7 @@ function Parser.parse_shift(): Node* {
 		if(op.type == TokenType::LSH) type = NodeType::LSH;
 		else if(op.type == TokenType::RSH) type = NodeType::RSH;
 
-		var binary = new_node(type, op);
+		var binary = new Node(type, op);
 		binary.binary.lhs = left;
 		binary.binary.rhs = right;
 		left = binary;
@@ -773,7 +791,7 @@ function Parser.parse_comparison(): Node* {
 		else if(op.type == TokenType::GREATER) type = NodeType::GREATER;
 		else if(op.type == TokenType::GEQ) type = NodeType::GREATER_EQ;
 
-		var binary = new_node(type, op);
+		var binary = new Node(type, op);
 		binary.binary.lhs = left;
 		binary.binary.rhs = right;
 		left = binary;
@@ -794,7 +812,7 @@ function Parser.parse_equality(): Node* {
 		if(op.type == TokenType::EQEQ) type = NodeType::EQUAL;
 		else if(op.type == TokenType::BANG_EQ) type = NodeType::NOT_EQUAL;
 
-		var binary = new_node(type, op);
+		var binary = new Node(type, op);
 		binary.binary.lhs = left;
 		binary.binary.rhs = right;
 		left = binary;
@@ -811,7 +829,7 @@ function Parser.parse_bwand(): Node* {
 
 		var right = this.parse_equality();
 
-		var binary = new_node(NodeType::BWAND, op);
+		var binary = new Node(NodeType::BWAND, op);
 		binary.binary.lhs = left;
 		binary.binary.rhs = right;
 		left = binary;
@@ -828,7 +846,7 @@ function Parser.parse_xor(): Node* {
 
 		var right = this.parse_bwand();
 
-		var binary = new_node(NodeType::XOR, op);
+		var binary = new Node(NodeType::XOR, op);
 		binary.binary.lhs = left;
 		binary.binary.rhs = right;
 		left = binary;
@@ -845,7 +863,7 @@ function Parser.parse_bwor(): Node* {
 
 		var right = this.parse_xor();
 
-		var binary = new_node(NodeType::BWOR, op);
+		var binary = new Node(NodeType::BWOR, op);
 		binary.binary.lhs = left;
 		binary.binary.rhs = right;
 		left = binary;
@@ -862,7 +880,7 @@ function Parser.parse_and(): Node* {
 
 		var right = this.parse_bwor();
 
-		var binary = new_node(NodeType::AND, op);
+		var binary = new Node(NodeType::AND, op);
 		binary.binary.lhs = left;
 		binary.binary.rhs = right;
 		left = binary;
@@ -879,7 +897,7 @@ function Parser.parse_or(): Node* {
 
 		var right = this.parse_and();
 
-		var binary = new_node(NodeType::OR, op);
+		var binary = new Node(NodeType::OR, op);
 		binary.binary.lhs = left;
 		binary.binary.rhs = right;
 		left = binary;
@@ -899,7 +917,7 @@ function Parser.parse_ternary_expression(): Node* {
 
 		var doFalse = this.parse_expression();
 
-		var ternary = new_node(NodeType::TERNARY, op);
+		var ternary = new Node(NodeType::TERNARY, op);
 		ternary.conditional.condition = condition;
 		ternary.conditional.doTrue = doTrue;
 		ternary.conditional.doFalse = doFalse;
@@ -924,7 +942,7 @@ function Parser.parse_assignment_expression(): Node* {
 
 		var right = this.parse_assignment_expression();
 
-		var assign = new_node(NodeType::ASSIGN, left.position);
+		var assign = new Node(NodeType::ASSIGN, left.position);
 		assign.assignment.lhs = left;
 		assign.assignment.rhs = right;
 		assign.assignment.op = op;
@@ -939,7 +957,7 @@ function Parser.parse_expression(): Node* {
 }
 
 function Parser.parse_if_statement(): Node* {
-	var ifStmt = new_node(NodeType::IF, this.previous);
+	var ifStmt = new Node(NodeType::IF, this.previous);
 
 	this.consume(TokenType::LEFT_PAREN, "Expected '(' after if");
 
@@ -957,7 +975,7 @@ function Parser.parse_if_statement(): Node* {
 }
 
 function Parser.parse_while_statement(): Node* {
-	var whileStmt = new_node(NodeType::WHILE, this.previous);
+	var whileStmt = new Node(NodeType::WHILE, this.previous);
 
 	this.consume(TokenType::LEFT_PAREN, "Expected '(' after while");
 
@@ -971,7 +989,7 @@ function Parser.parse_while_statement(): Node* {
 }
 
 function Parser.parse_do_while_statement(): Node* {
-	var doStmt = new_node(NodeType::DO_WHILE, this.previous);
+	var doStmt = new Node(NodeType::DO_WHILE, this.previous);
 
 	doStmt.conditional.doTrue = this.parse_statement();
 
@@ -989,9 +1007,9 @@ function Parser.parse_do_while_statement(): Node* {
 }
 
 function Parser.parse_for_statement(): Node* {
-	var forStmt = new_node(NodeType::FOR, this.previous);
+	var forStmt = new Node(NodeType::FOR, this.previous);
 
-	var block = new_node(NodeType::BLOCK, this.previous);
+	var block = new Node(NodeType::BLOCK, this.previous);
 	block.block.children = new Vector();
 	block.block.parent = this.currentBlock;
 	this.currentBlock = block;
@@ -1031,7 +1049,7 @@ function Parser.parse_for_statement(): Node* {
 }
 
 function Parser.parse_return_statement(): Node* {
-	var returnStmt = new_node(NodeType::RETURN, this.previous);
+	var returnStmt = new Node(NodeType::RETURN, this.previous);
 
 	if(!this.check(TokenType::SEMICOLON))
 		returnStmt.ret.value = this.parse_expression();
@@ -1042,7 +1060,7 @@ function Parser.parse_return_statement(): Node* {
 }
 
 function Parser.parse_array_initialization(): Node* {
-	var array = new_node(NodeType::ARRAY_INIT, this.previous);
+	var array = new Node(NodeType::ARRAY_INIT, this.previous);
 	array.block.children = new Vector();
 
 	if(!this.check(TokenType::RIGHT_SQBR)) {
@@ -1064,7 +1082,7 @@ function Parser.parse_var_declaration(): Node* {
 		type = this.parse_type();
 	}
 
-	var variable = new_node(NodeType::DEFINE_VAR, name);
+	var variable = new Node(NodeType::DEFINE_VAR, name);
 	this.bind_name(&variable.variable.name, name);
 	variable.variable.type = type;
 	variable.variable.value = null;
@@ -1113,7 +1131,7 @@ function Parser.parse_when_statement(): Node* {
 
 	if(this.match(TokenType::RIGHT_BRACE)) this.error("Expected at least one when branch");
 
-	var vhen = new_node(NodeType::WHEN, vhenTok);
+	var vhen = new Node(NodeType::WHEN, vhenTok);
 	vhen.vhen.match = match;
 	vhen.vhen.branches = new Vector();
 
@@ -1124,7 +1142,7 @@ function Parser.parse_when_statement(): Node* {
 			break;
 		}
 
-		var branch = new_node(NodeType::BRANCH, this.current);
+		var branch = new Node(NodeType::BRANCH, this.current);
 		branch.branch.values = new Vector();
 
 		var value = this.parse_constant();
@@ -1157,7 +1175,7 @@ function Parser.parse_delete_statement(): Node* {
 	
 	this.consume(TokenType::SEMICOLON, "Expected ';' after delete expression");
 
-	var node = new_node(NodeType::DELETE, keyword);
+	var node = new Node(NodeType::DELETE, keyword);
 	node.deconstructor.value = expr;
 	node.deconstructor.shouldDeconstruct = false;
 	return node;
@@ -1170,7 +1188,7 @@ function Parser.parse_delete_array_statement(): Node* {
 	
 	this.consume(TokenType::SEMICOLON, "Expected ';' after delete[] expression");
 
-	var node = new_node(NodeType::DELETE_ARRAY, keyword);
+	var node = new Node(NodeType::DELETE_ARRAY, keyword);
 	node.deconstructor.value = expr;
 	node.deconstructor.shouldDeconstruct = false;
 	return node;
@@ -1180,13 +1198,13 @@ function Parser.parse_statement(): Node* {
 	if(this.match(TokenType::BREAK)) {
 		var pos = this.previous;
 		this.consume(TokenType::SEMICOLON, "Expected ';' after 'break'");
-		var breac = new_node(NodeType::BREAK, pos);
+		var breac = new Node(NodeType::BREAK, pos);
 		return breac;
 	}
 	else if(this.match(TokenType::CONTINUE)) {
 		var pos = this.previous;
 		this.consume(TokenType::SEMICOLON, "Expected ';' after 'continue'");
-		var kontinue = new_node(NodeType::CONTINUE, pos);
+		var kontinue = new Node(NodeType::CONTINUE, pos);
 		return kontinue;
 	}
 	else if(this.match(TokenType::DELETE)) {
@@ -1231,14 +1249,14 @@ function Parser.parse_statement(): Node* {
 
 	this.consume(TokenType::SEMICOLON, "Expected ';' after expression");
 
-	var exprStmt = new_node(NodeType::EXPR_STMT, expr.position);
+	var exprStmt = new Node(NodeType::EXPR_STMT, expr.position);
 	exprStmt.unary = expr;
 
 	return exprStmt;
 }
 
 function Parser.parse_block(): Node* {
-	var block = new_node(NodeType::BLOCK, this.previous);
+	var block = new Node(NodeType::BLOCK, this.previous);
 	block.block.children = new Vector();
 	block.block.parent = this.currentBlock;
 	this.currentBlock = block;
@@ -1258,10 +1276,10 @@ function Parser.parse_block(): Node* {
 function Parser.parse_function(): Node* {
 	var name = this.consume(TokenType::IDENTIFIER, "Expected function name");
 
-	var funktion = new_node(NodeType::FUNCTION, name);
+	var funktion = new Node(NodeType::FUNCTION, name);
 	funktion.funktion.arguments = new Vector();
 
-	var nameSpace = new_namespace(null, null);
+	var nameSpace = new Namespace(null, null);
 	nameSpace.parts = new Vector();
 
 	while(this.match(TokenType::COLON_COLON)) {
@@ -1289,7 +1307,7 @@ function Parser.parse_function(): Node* {
 
 		type.indirection = 1;
 
-		var thisNode = new_node(NodeType::DEFINE_VAR, synthThis);
+		var thisNode = new Node(NodeType::DEFINE_VAR, synthThis);
 		this.bind_name(&thisNode.variable.name, synthThis);
 		thisNode.variable.type = type;
 
@@ -1319,7 +1337,7 @@ function Parser.parse_function(): Node* {
 			this.consume(TokenType::COLON, "Expected ':' after parameter name");
 			var type = this.parse_type();
 
-			var arg = new_node(NodeType::DEFINE_VAR, argName);
+			var arg = new Node(NodeType::DEFINE_VAR, argName);
 			this.bind_name(&arg.variable.name, argName);
 			arg.variable.type = type;
 
@@ -1364,7 +1382,7 @@ function Parser.parse_member_definition(type: Type*) {
 		this.bind_name(&vnion.variable.name, memName);
 		this.bind_name(&vnion.computedType.name, memName);
 
-		var member = new_node(NodeType::MEMBER, memName);
+		var member = new Node(NodeType::MEMBER, memName);
 		this.bind_name(&member.variable.name, memName);
 		member.variable.type = vnion.computedType;
 		member.variable.value = vnion;
@@ -1379,7 +1397,7 @@ function Parser.parse_member_definition(type: Type*) {
 		this.bind_name(&strukt.variable.name, memName);
 		this.bind_name(&strukt.computedType.name, memName);
 
-		var member = new_node(NodeType::MEMBER, memName);
+		var member = new Node(NodeType::MEMBER, memName);
 		this.bind_name(&member.variable.name, memName);
 		member.variable.type = strukt.computedType;
 		member.variable.value = strukt;
@@ -1391,7 +1409,7 @@ function Parser.parse_member_definition(type: Type*) {
 
 		this.consume(TokenType::SEMICOLON, "Expected ';' after member declaration");
 
-		var member = new_node(NodeType::MEMBER, memName);
+		var member = new Node(NodeType::MEMBER, memName);
 		this.bind_name(&member.variable.name, memName);
 		member.variable.type = memType;
 
@@ -1402,7 +1420,7 @@ function Parser.parse_member_definition(type: Type*) {
 function Parser.parse_struct_definition(member: int): Node* {
 	var name: Token*;
 
-	var strukt = new_node(NodeType::STRUCT, name);
+	var strukt = new Node(NodeType::STRUCT, name);
 
 	if(!member) {
 		name = this.consume(TokenType::IDENTIFIER, "Expected struct name");
@@ -1459,7 +1477,7 @@ function Parser.parse_struct_definition(member: int): Node* {
 function Parser.parse_union_definition(member: int): Node* {
 	var name: Token*;
 
-	var vnion = new_node(NodeType::UNION, name);
+	var vnion = new Node(NodeType::UNION, name);
 	
 	if(!member) {
 		name = this.consume(TokenType::IDENTIFIER, "Expected union name");
@@ -1501,7 +1519,7 @@ function Parser.parse_union_definition(member: int): Node* {
 function Parser.parse_const_declaration(): Node* {
 	var name = this.consume(TokenType::IDENTIFIER, "Expected constant name");
 
-	var constant = new_node(NodeType::DEFINE_CONST, name);
+	var constant = new Node(NodeType::DEFINE_CONST, name);
 	this.namespace_name(&constant.constant.name, name);
 
 	if(this.lookup_constant(&constant.constant.name) != null) {
@@ -1526,17 +1544,17 @@ function Parser.parse_enum_declaration(): Node* {
 
 	this.consume(TokenType::LEFT_BRACE, "Expected '{' after enum name");
 
-	var nameSpace = new_namespace(name, this.namespaceStack.empty() ? null : this.namespaceStack.top());
+	var nameSpace = new Namespace(name, this.namespaceStack.empty() ? null : this.namespaceStack.top());
 
 	this.namespaceStack.push(nameSpace);
 
-	var namespaceNode = new_node(NodeType::NAMESPACE, name);
+	var namespaceNode = new Node(NodeType::NAMESPACE, name);
 	namespaceNode.nameSpace.name = nameSpace;
-	var namespaceBody = new_node(NodeType::BLOCK, name);
+	var namespaceBody = new Node(NodeType::BLOCK, name);
 	namespaceBody.block.children = new Vector();
 	namespaceNode.nameSpace.body = namespaceBody;
 
-	var envm = new_node(NodeType::ENUM, name);
+	var envm = new Node(NodeType::ENUM, name);
 	envm.block.children = new Vector();
 
 	var count = 0;
@@ -1544,7 +1562,7 @@ function Parser.parse_enum_declaration(): Node* {
 	do {
 		var constantName = this.consume(TokenType::IDENTIFIER, "Expected constant name");
 
-		var constant = new_node(NodeType::DEFINE_CONST, name);
+		var constant = new Node(NodeType::DEFINE_CONST, name);
 		this.namespace_name(&constant.constant.name, constantName);
 		constant.constant.value = count;
 
@@ -1608,7 +1626,7 @@ function Parser.parse_import() {
 	var source = file.slurp(null);
 	file.close();
 
-	var lexer = new_lexer(spath, source);
+	var lexer = new Lexer(spath, source);
 
 	this.lexerStack.push(lexer);
 	this.openedFiles.push(spath);
@@ -1637,7 +1655,7 @@ function Parser.parse_alias() {
 
 function Parser.parse_namespace(): Node* {
 	var namespaceName = this.consume(TokenType::IDENTIFIER, "Expected namespace name");
-	var nameSpace = new_namespace(namespaceName, this.namespaceStack.empty() ? null : this.namespaceStack.top());
+	var nameSpace = new Namespace(namespaceName, this.namespaceStack.empty() ? null : this.namespaceStack.top());
 
 	while(this.match(TokenType::COLON_COLON)) {
 		namespaceName = this.consume(TokenType::IDENTIFIER, "Expected identifier");
@@ -1648,9 +1666,9 @@ function Parser.parse_namespace(): Node* {
 
 	this.consume(TokenType::LEFT_BRACE, "Expected '{' after namespace name");
 
-	var namespaceNode = new_node(NodeType::NAMESPACE, namespaceName);
+	var namespaceNode = new Node(NodeType::NAMESPACE, namespaceName);
 
-	var body = new_node(NodeType::BLOCK, this.previous);
+	var body = new Node(NodeType::BLOCK, this.previous);
 	body.block.children = new Vector();
 
 	namespaceNode.nameSpace.name = nameSpace;
@@ -1705,7 +1723,7 @@ function Parser.parse_top_level_declaration(block: Node*) {
 }
 
 function Parser.parse_program(): Node* {
-	var program = new_node(NodeType::PROGRAM, this.current);
+	var program = new Node(NodeType::PROGRAM, this.current);
 	program.block.children = new Vector();
 
 	this.advance();

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -546,8 +546,8 @@ function Parser.parse_value(): Node* {
 			return literalNode;
 		}
 
-		free(buf);
-		free(literalNode);
+		delete buf;
+		delete literalNode;
 		return str;
 	}
 	else if(this.match(TokenType::IDENTIFIER)) {

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -35,7 +35,7 @@ struct Parser {
 }
 
 function new_parser(lexer: Lexer*): Parser* {
-	var parser: Parser* = malloc(sizeof(Parser));
+	var parser = new Parser;
 	parser.lexer = lexer;
 	parser.functions = new std::map::HashMap();
 	parser.globalVars = new Vector();
@@ -50,7 +50,7 @@ function new_parser(lexer: Lexer*): Parser* {
 }
 
 function new_node(type: int, position: Token*): Node* {
-	var node: Node* = malloc(sizeof(Node));
+	var node: Node* = new Node;
 	node.type = type;
 	node.position = position;
 	return node;
@@ -230,7 +230,7 @@ function Parser.find_string(needle: Node*): Node* {
 function Parser.parse_type_no_array(): Type* {
 	this.advance();
 
-	var type = new_type();
+	var type = new Type;
 
 	when(this.previous.type) {
 		TokenType::INT -> type.type = DataType::INT;
@@ -516,7 +516,7 @@ function Parser.parse_value(): Node* {
 		var literalNode = new_node(NodeType::FLOAT_LITERAL, literal);
 		literalNode.literal.type = F64_TYPE;
 
-		var str: i8* = malloc(literal.length + 1);
+		var str = new i8[literal.length + 1];
 		memcpy(str, literal.start, literal.length);
 		str[literal.length] = 0;
 
@@ -533,7 +533,7 @@ function Parser.parse_value(): Node* {
 		var literalNode = new_node(NodeType::STRING, literal);
 		literalNode.literal.type = STR_TYPE;
 
-		var buf: i8* = malloc(literal.length - 2 + 1);
+		var buf = new i8[literal.length - 2 + 1];
 		this.escape_string(literal, buf);
 
 		literalNode.literal.az.string.chars = buf;
@@ -1282,7 +1282,7 @@ function Parser.parse_function(): Node* {
 		var methodName = this.consume(TokenType::IDENTIFIER, "Expected function name");
 
 		var synthThis = synthetic_token(TokenType::IDENTIFIER, "this");
-		var type = new_type();
+		var type = new Type;
 		type.type = DataType::UNRESOLVED;
 		this.bind_name(&type.name, name);
 		if(nameSpace.parts.size > 0) bind_to_namespace(&type.name, nameSpace);
@@ -1418,7 +1418,7 @@ function Parser.parse_struct_definition(member: int): Node* {
 
 	if(this.match(TokenType::RIGHT_BRACE)) this.error("Expected at least one struct member");
 
-	var structType = new_type();
+	var structType = new Type;
 	structType.type = DataType::STRUCT;
 	if(!member)
 		this.namespace_name(&structType.name, name);
@@ -1475,7 +1475,7 @@ function Parser.parse_union_definition(member: int): Node* {
 
 	if(this.match(TokenType::RIGHT_BRACE)) this.error("Expected at least one union member");
 
-	var unionType = new_type();
+	var unionType = new Type;
 	unionType.type = DataType::UNION;
 	if(!member)
 		this.namespace_name(&unionType.name, name);
@@ -1561,7 +1561,7 @@ function Parser.parse_enum_declaration(): Node* {
 
 	this.namespaceStack.pop();
 
-	var alius = new_type();
+	var alius = new Type;
 	alius.type = DataType::ALIAS;
 	this.namespace_name(&alius.name, name);
 	alius.aliased = INT_TYPE;
@@ -1579,7 +1579,7 @@ function Parser.parse_import() {
 	var path = this.consume(TokenType::STRING, "Expected import path");
 	this.consume(TokenType::SEMICOLON, "Expected ';' after import");
 
-	var spath: i8* = malloc(path.length - 2 + 1);
+	var spath = new i8[path.length - 2 + 1];
 	memcpy(spath, &path.start[1], path.length - 2);
 	spath[path.length - 2] = 0;
 
@@ -1623,7 +1623,7 @@ function Parser.parse_alias() {
 
 	this.consume(TokenType::SEMICOLON, "Expected ';' after alias");
 
-	var alius = new_type();
+	var alius = new Type;
 	alius.type = DataType::ALIAS;
 	this.namespace_name(&alius.name, aliasName);
 	alius.aliased = aliasType;

--- a/src/parser.zpr
+++ b/src/parser.zpr
@@ -38,14 +38,14 @@ function new_parser(lexer: Lexer*): Parser* {
 	var parser: Parser* = malloc(sizeof(Parser));
 	parser.lexer = lexer;
 	parser.functions = new std::map::HashMap();
-	parser.globalVars = new_vector();
-	parser.strings = new_vector();
-	parser.floats = new_vector();
-	parser.definedTypes = new_vector();
-	parser.lexerStack = new_vector();
-	parser.openedFiles = new_vector();
-	parser.constants = new_vector();
-	parser.namespaceStack = new_vector();
+	parser.globalVars = new Vector();
+	parser.strings = new Vector();
+	parser.floats = new Vector();
+	parser.definedTypes = new Vector();
+	parser.lexerStack = new Vector();
+	parser.openedFiles =  new Vector();
+	parser.constants = new Vector();
+	parser.namespaceStack = new Vector();
 	return parser;
 }
 
@@ -92,7 +92,7 @@ function Parser.add_function(funktion: Node*) {
 		list.push(funktion);
 	}
 	else {
-		list = new_vector();
+		list = new Vector();
 		list.push(funktion);
 		this.functions.set(nameStr, list);
 	}
@@ -252,7 +252,7 @@ function Parser.parse_type_no_array(): Type* {
 			var name = this.previous;
 
 			var nameSpace = new_namespace(null, null);
-			nameSpace.parts = new_vector();
+			nameSpace.parts = new Vector();
 
 			while(this.match(TokenType::COLON_COLON)) {
 				nameSpace.parts.push(name);
@@ -405,7 +405,7 @@ function Parser.parse_constant(): int {
 function Parser.parse_call(name: Token*): Node* {
 	var call = new_node(NodeType::CALL, name);
 	this.bind_name(&call.funktion.name, name);
-	call.funktion.arguments = new_vector();
+	call.funktion.arguments = new Vector();
 
 	if(!this.check(TokenType::RIGHT_PAREN)) {
 		var arg = this.parse_expression();
@@ -428,7 +428,7 @@ function Parser.parse_identifier(): Node* {
 	var name = this.previous;
 
 	var nameSpace = new_namespace(null, null);
-	nameSpace.parts = new_vector();
+	nameSpace.parts = new Vector();
 
 	while(this.match(TokenType::COLON_COLON)) {
 		nameSpace.parts.push(name);
@@ -454,7 +454,7 @@ function Parser.parse_new(): Node* {
 
 	var node = new_node(NodeType::NEW, keyword);
 	node.constructor.type = type;
-	node.constructor.arguments = new_vector();
+	node.constructor.arguments = new Vector();
 
 	if(this.match(TokenType::LEFT_PAREN)) {
 		if(!this.check(TokenType::RIGHT_PAREN)) {
@@ -992,7 +992,7 @@ function Parser.parse_for_statement(): Node* {
 	var forStmt = new_node(NodeType::FOR, this.previous);
 
 	var block = new_node(NodeType::BLOCK, this.previous);
-	block.block.children = new_vector();
+	block.block.children = new Vector();
 	block.block.parent = this.currentBlock;
 	this.currentBlock = block;
 
@@ -1043,7 +1043,7 @@ function Parser.parse_return_statement(): Node* {
 
 function Parser.parse_array_initialization(): Node* {
 	var array = new_node(NodeType::ARRAY_INIT, this.previous);
-	array.block.children = new_vector();
+	array.block.children = new Vector();
 
 	if(!this.check(TokenType::RIGHT_SQBR)) {
 		do {
@@ -1080,7 +1080,7 @@ function Parser.parse_var_declaration(): Node* {
 	}
 
 	else if(type != VOID_TYPE && this.match(TokenType::LEFT_PAREN)) {
-		variable.variable.arguments = new_vector();
+		variable.variable.arguments = new Vector();
 		if(!this.check(TokenType::RIGHT_PAREN)) {
 			var arg = this.parse_expression();
 
@@ -1115,7 +1115,7 @@ function Parser.parse_when_statement(): Node* {
 
 	var vhen = new_node(NodeType::WHEN, vhenTok);
 	vhen.vhen.match = match;
-	vhen.vhen.branches = new_vector();
+	vhen.vhen.branches = new Vector();
 
 	while(!this.check(TokenType::RIGHT_BRACE)) {
 		if(this.match(TokenType::ELSE)) {
@@ -1125,7 +1125,7 @@ function Parser.parse_when_statement(): Node* {
 		}
 
 		var branch = new_node(NodeType::BRANCH, this.current);
-		branch.branch.values = new_vector();
+		branch.branch.values = new Vector();
 
 		var value = this.parse_constant();
 		branch.branch.values.push(value as any*);
@@ -1239,7 +1239,7 @@ function Parser.parse_statement(): Node* {
 
 function Parser.parse_block(): Node* {
 	var block = new_node(NodeType::BLOCK, this.previous);
-	block.block.children = new_vector();
+	block.block.children = new Vector();
 	block.block.parent = this.currentBlock;
 	this.currentBlock = block;
 
@@ -1259,10 +1259,10 @@ function Parser.parse_function(): Node* {
 	var name = this.consume(TokenType::IDENTIFIER, "Expected function name");
 
 	var funktion = new_node(NodeType::FUNCTION, name);
-	funktion.funktion.arguments = new_vector();
+	funktion.funktion.arguments = new Vector();
 
 	var nameSpace = new_namespace(null, null);
-	nameSpace.parts = new_vector();
+	nameSpace.parts = new Vector();
 
 	while(this.match(TokenType::COLON_COLON)) {
 		nameSpace.parts.push(name);
@@ -1425,7 +1425,7 @@ function Parser.parse_struct_definition(member: int): Node* {
 	else
 		this.bind_name(&structType.name, name);
 
-	structType.fields = new_vector();
+	structType.fields = new Vector();
 	structType.methods = new std::map::HashMap;
 
 	do {
@@ -1481,7 +1481,7 @@ function Parser.parse_union_definition(member: int): Node* {
 		this.namespace_name(&unionType.name, name);
 	else
 		this.bind_name(&unionType.name, name);
-	unionType.fields = new_vector();
+	unionType.fields = new Vector();
 
 	do {
 		this.parse_member_definition(unionType);
@@ -1533,11 +1533,11 @@ function Parser.parse_enum_declaration(): Node* {
 	var namespaceNode = new_node(NodeType::NAMESPACE, name);
 	namespaceNode.nameSpace.name = nameSpace;
 	var namespaceBody = new_node(NodeType::BLOCK, name);
-	namespaceBody.block.children = new_vector();
+	namespaceBody.block.children = new Vector();
 	namespaceNode.nameSpace.body = namespaceBody;
 
 	var envm = new_node(NodeType::ENUM, name);
-	envm.block.children = new_vector();
+	envm.block.children = new Vector();
 
 	var count = 0;
 
@@ -1651,7 +1651,7 @@ function Parser.parse_namespace(): Node* {
 	var namespaceNode = new_node(NodeType::NAMESPACE, namespaceName);
 
 	var body = new_node(NodeType::BLOCK, this.previous);
-	body.block.children = new_vector();
+	body.block.children = new Vector();
 
 	namespaceNode.nameSpace.name = nameSpace;
 	namespaceNode.nameSpace.body = body;
@@ -1706,7 +1706,7 @@ function Parser.parse_top_level_declaration(block: Node*) {
 
 function Parser.parse_program(): Node* {
 	var program = new_node(NodeType::PROGRAM, this.current);
-	program.block.children = new_vector();
+	program.block.children = new Vector();
 
 	this.advance();
 

--- a/src/token.zpr
+++ b/src/token.zpr
@@ -237,7 +237,7 @@ function Token.equals(b: Token*): bool {
 }
 
 function synthetic_token(type: TokenType, value: i8*): Token* {
-	var token: Token* = malloc(sizeof(Token));
+	var token: Token* = new Token;
 	token.line = 0;
 	token.type = type;
 	token.start = value;
@@ -246,7 +246,7 @@ function synthetic_token(type: TokenType, value: i8*): Token* {
 }
 
 function Token.name_to_str(): i8* {
-	var name: i8* = malloc(this.length + 1);
+	var name: i8* = new i8[this.length + 1];
 	memcpy(name, this.start, this.length);
 	name[this.length] = 0;
 	return name;

--- a/src/token.zpr
+++ b/src/token.zpr
@@ -100,12 +100,29 @@ enum TokenType {
 	EOF
 }
 
+var __allTokens: Vector* = null;
+
 struct Token {
 	type: TokenType;
 	start: i8*;
 	length: int;
 	line: int;
 	filename: i8*;
+}
+
+function Token.constructor() {
+	if(__allTokens == null) {
+		__allTokens = new Vector;
+	}
+	__allTokens.push(this);
+}
+
+function free_tokens() {
+	if(__allTokens == null) return;
+	for(var i = 0; i < __allTokens.size; ++i) {
+		delete __allTokens.at(i);
+	}
+	delete __allTokens;
 }
 
 function token_type_to_string(type: TokenType): i8* {

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -4,13 +4,13 @@ import "std/math.zpr";
 
 namespace Typecheck {
 
-var typeStack = new_vector();
-var definedTypes = new_vector();
-var namespaces = new_vector();
+var typeStack = new Vector();
+var definedTypes: Vector* = new Vector();
+var namespaces: Vector* = new Vector();
 
 var checkingLoop = false;
 var temporaryOffset = 0;
-var temporaries = new_vector();
+var temporaries = new Vector();
 
 function Type.is_integral(): bool {
 	return this.indirection == 0 && (
@@ -518,10 +518,10 @@ function get_name_from_overload(op: Token*): Name* {
 function get_overload_function(lhs: Type*, rhs: Type*, op: Token*): Node* {
 	var name = get_name_from_overload(op);
 
-	var args = new_vector();
+	var args: Vector;
 	args.push(rhs);
 
-	var copy = lhs.lookup_method_with_arguments(name, args);
+	var copy = lhs.lookup_method_with_arguments(name, &args);
 	return copy;
 }
 
@@ -732,7 +732,7 @@ function Parser.type_check_call(expr: Node*) {
 		exit(1);
 	}
 
-	var argTypes = new_vector();
+	var argTypes: Vector;
 	for(var i = 0; i < expr.funktion.arguments.size; ++i) {
 		var arg: Node* = expr.funktion.arguments.at(i);
 		this.type_check_expr(arg);
@@ -741,18 +741,18 @@ function Parser.type_check_call(expr: Node*) {
 		argTypes.push(argType);
 	}
 
-	var func = this.lookup_function_with_arguments(&expr.funktion.name, argTypes);
+	var func = this.lookup_function_with_arguments(&expr.funktion.name, &argTypes);
 
 	if(func == null) {
 		expr.print_position();
 		eputs("Failed to resolve function '"); expr.funktion.name.eput(); eputsln("'");
-		eputs("Given argument types: "); eput_argument_types(argTypes); eputln();
+		eputs("Given argument types: "); eput_argument_types(&argTypes); eputln();
 		exit(1);
 	}
 
 	var paramTypes = func.funktion.argTypes;
 	if(paramTypes == null) {
-		paramTypes = new_vector();
+		paramTypes = new Vector();
 		for(var i = 0; i < func.funktion.arguments.size; ++i) {
 			var type: Type* = (func.funktion.arguments.at(i) as Node*).variable.type;
 			resolve_type(type);
@@ -768,12 +768,11 @@ function Parser.type_check_call(expr: Node*) {
 			var deconstructorName: Name;
 			this.bind_name(&deconstructorName, deconstructorTok);
 
-			var argTypes = new_vector();
 			var deconstructors = func.funktion.returnType.lookup_method(&deconstructorName);
 
 			if(deconstructors != null) {
-				var argTypes = new_vector();
-				var deconstructor = func.funktion.returnType.lookup_method_with_arguments(&deconstructorName, argTypes);
+				var argTypes: Vector;
+				var deconstructor = func.funktion.returnType.lookup_method_with_arguments(&deconstructorName, &argTypes);
 				if(deconstructor == null) {
 					expr.print_position();
 					eputs("The deconstructor of type "); eputs(type_to_string(func.funktion.returnType)); eputsln(" must have 0 arguments");
@@ -813,7 +812,7 @@ function Parser.type_check_method_call(expr: Node*) {
 
 	expr.funktion.parentType = parentType;
 
-	var argTypes = new_vector();
+	var argTypes: Vector;
 	for(var i = 0; i < expr.funktion.arguments.size; ++i) {
 		var arg: Node* = expr.funktion.arguments.at(i);
 		this.type_check_expr(arg);
@@ -822,18 +821,18 @@ function Parser.type_check_method_call(expr: Node*) {
 		argTypes.push(argType);
 	}
 
-	var funktion = parentType.lookup_method_with_arguments(&name, argTypes);
+	var funktion = parentType.lookup_method_with_arguments(&name, &argTypes);
 
 	if(funktion == null) {
 		expr.print_position();
 		eputs("Failed to resolve method '"); expr.funktion.name.eput(); eputs("' of type "); eputsln(type_to_string(parentType));
-		eputs("Given argument types: "); eput_argument_types(argTypes); eputln();
+		eputs("Given argument types: "); eput_argument_types(&argTypes); eputln();
 		exit(1);
 	}
 
 	var paramTypes = funktion.funktion.argTypes;
 	if(paramTypes == null) {
-		paramTypes = new_vector();
+		paramTypes = new Vector();
 		for(var i = 1; i < funktion.funktion.arguments.size; ++i) {
 			var type: Type* = (funktion.funktion.arguments.at(i) as Node*).variable.type;
 			resolve_type(type);
@@ -983,12 +982,12 @@ function Parser.type_check_assign(expr: Node*) {
 			var copyName: Name;
 			this.bind_name(&copyName, copyTok);
 
-			var args = new_vector();
+			var args: Vector;
 			var typePtr = copy_type(lhs);
 			typePtr.indirection = 1;
 			args.push(typePtr);
 
-			var copy = lhs.lookup_method_with_arguments(&copyName, args);
+			var copy = lhs.lookup_method_with_arguments(&copyName, &args);
 
 			if(copy != null) {
 				var overload = new_node(NodeType::OVERLOAD, expr.position);
@@ -1037,10 +1036,10 @@ function Parser.resolve_malloc_function(): Node* {
 	var mallocName: Name;
 	this.bind_name(&mallocName, mallocTok);
 
-	var arguments = new_vector();
+	var arguments: Vector;
 	arguments.push(UINT_TYPE);
 
-	var mallocFunc = this.lookup_function_with_arguments(&mallocName, arguments);
+	var mallocFunc = this.lookup_function_with_arguments(&mallocName, &arguments);
 
 	if(mallocFunc == null) return null;
 	if(mallocFunc.funktion.name.namespaceName != null) return null;
@@ -1077,7 +1076,7 @@ function Parser.type_check_new(expr: Node*) {
 			expr.constructor.arguments = null;
 		}
 		else {
-			var argTypes = new_vector();
+			var argTypes: Vector;
 			for(var i = 0; i < expr.constructor.arguments.size; ++i) {
 				var arg: Node* = expr.constructor.arguments.at(i);
 				this.type_check_expr(arg);
@@ -1086,18 +1085,18 @@ function Parser.type_check_new(expr: Node*) {
 				argTypes.push(argType);
 			}
 
-			var constructor = expr.constructor.type.lookup_method_with_arguments(&constructorName, argTypes);
+			var constructor = expr.constructor.type.lookup_method_with_arguments(&constructorName, &argTypes);
 
 			if(constructor == null) {
 				expr.print_position();
 				eputs("Failed to resolve constructor"); eputs(" of type "); eputsln(type_to_string(expr.constructor.type));
-				eputs("Given argument types: "); eput_argument_types(argTypes); eputln();
+				eputs("Given argument types: "); eput_argument_types(&argTypes); eputln();
 				exit(1);
 			}
 
 			var paramTypes = constructor.funktion.argTypes;
 			if(paramTypes == null) {
-				paramTypes = new_vector();
+				paramTypes = new Vector();
 				for(var i = 1; i < constructor.funktion.arguments.size; ++i) {
 					var type: Type* = (constructor.funktion.arguments.at(i) as Node*).variable.type;
 					resolve_type(type);
@@ -1137,8 +1136,8 @@ function Parser.type_check_new_array(expr: Node*) {
 			expr.constructor.shouldConstruct = false;
 		}
 		else {
-			var argTypes = new_vector();
-			var constructorMethod = expr.constructor.type.lookup_method_with_arguments(&constructorName, argTypes);
+			var argTypes: Vector;
+			var constructorMethod = expr.constructor.type.lookup_method_with_arguments(&constructorName, &argTypes);
 
 			if(constructorMethod == null) {
 				eputs("Failed to resolve default constructor"); eputs(" of type "); eputsln(type_to_string(expr.constructor.type));
@@ -1358,12 +1357,12 @@ function Parser.type_check_define_var(stmt: Node*) {
 			var copyName: Name;
 			this.bind_name(&copyName, copyTok);
 
-			var args = new_vector();
+			var args: Vector;
 			var typePtr = copy_type(declType);
 			typePtr.indirection = 1;
 			args.push(typePtr);
 
-			var copy = declType.lookup_method_with_arguments(&copyName, args);
+			var copy = declType.lookup_method_with_arguments(&copyName, &args);
 
 			if(copy != null) {
 				stmt.variable.copyConstructor = true;
@@ -1396,7 +1395,7 @@ function Parser.type_check_define_var(stmt: Node*) {
 			stmt.variable.arguments = null;
 		}
 		else {
-			var argTypes = new_vector();
+			var argTypes: Vector;
 			for(var i = 0; i < stmt.variable.arguments.size; ++i) {
 				var arg: Node* = stmt.variable.arguments.at(i);
 				this.type_check_expr(arg);
@@ -1405,18 +1404,18 @@ function Parser.type_check_define_var(stmt: Node*) {
 				argTypes.push(argType);
 			}
 
-			var constructor = stmt.variable.type.lookup_method_with_arguments(&constructorName, argTypes);
+			var constructor = stmt.variable.type.lookup_method_with_arguments(&constructorName, &argTypes);
 
 			if(constructor == null) {
 				stmt.print_position();
 				eputs("Failed to resolve constructor"); eputs(" of type "); eputsln(type_to_string(stmt.variable.type));
-				eputs("Given argument types: "); eput_argument_types(argTypes); eputln();
+				eputs("Given argument types: "); eput_argument_types(&argTypes); eputln();
 				exit(1);
 			}
 
 			var paramTypes = constructor.funktion.argTypes;
 			if(paramTypes == null) {
-				paramTypes = new_vector();
+				paramTypes = new Vector();
 				for(var i = 1; i < constructor.funktion.arguments.size; ++i) {
 					var type: Type* = (constructor.funktion.arguments.at(i) as Node*).variable.type;
 					resolve_type(type);
@@ -1437,9 +1436,9 @@ function Parser.type_check_define_var(stmt: Node*) {
 		var constructors = stmt.variable.type.lookup_method(&constructorName);
 
 		if(constructors != null) {
-			stmt.variable.arguments = new_vector();
+			stmt.variable.arguments = new Vector();
 			
-			var argTypes = new_vector();
+			var argTypes = new Vector();
 			var constructor = stmt.variable.type.lookup_method_with_arguments(&constructorName, argTypes);
 
 			if(constructor == null) {
@@ -1507,7 +1506,7 @@ function Parser.type_check_do_while_statement(stmt: Node*) {
 	if(stmt.conditional.doTrue.type == NodeType::BLOCK) {
 		var block = stmt.conditional.doTrue;
 
-		block.block.variables = new_vector();
+		block.block.variables = new Vector();
 		block.block.currentStackOffset = this.currentBlock.block.currentStackOffset;
 		this.currentBlock = block;
 
@@ -1606,7 +1605,7 @@ function Parser.resolve_free_function(): Node* {
 	var freeName: Name;
 	this.bind_name(&freeName, freeTok);
 
-	var arguments = new_vector();
+	var arguments = new Vector();
 	arguments.push(ANYP_TYPE);
 
 	var freeFunc = this.lookup_function_with_arguments(&freeName, arguments);
@@ -1640,14 +1639,13 @@ function Parser.type_check_delete_statement(stmt: Node*) {
 		var deconstructorName: Name;
 		this.bind_name(&deconstructorName, deconstructorTok);
 
-		var argTypes = new_vector();
 		var deconstructors = targetType.lookup_method(&deconstructorName);
 
 		if(deconstructors != null) {
 			stmt.deconstructor.shouldDeconstruct = true;
 
-			var argTypes = new_vector();
-			var deconstructor = targetType.lookup_method_with_arguments(&deconstructorName, argTypes);
+			var argTypes: Vector;
+			var deconstructor = targetType.lookup_method_with_arguments(&deconstructorName, &argTypes);
 			if(deconstructor == null) {
 				stmt.print_position();
 				eputs("The deconstructor of type "); eputs(type_to_string(targetType)); eputsln(" must have 0 arguments");
@@ -1664,7 +1662,7 @@ function Parser.resolve_get_array_length_function(): Node* {
 	this.bind_name(&funcName, funcTok);
 
 	var nameSpace = new_namespace(null, null);
-	nameSpace.parts = new_vector();
+	nameSpace.parts = new Vector();
 
 	nameSpace.parts.push(synthetic_token(TokenType::IDENTIFIER, "std"));
 	nameSpace.parts.push(synthetic_token(TokenType::IDENTIFIER, "internal"));
@@ -1672,11 +1670,11 @@ function Parser.resolve_get_array_length_function(): Node* {
 
 	bind_to_namespace(&funcName, nameSpace);
 
-	var arguments = new_vector();
+	var arguments: Vector;
 	arguments.push(ANYP_TYPE);
 	arguments.push(UINT_TYPE);
 
-	var func = this.lookup_function_with_arguments(&funcName, arguments);
+	var func = this.lookup_function_with_arguments(&funcName, &arguments);
 
 	if(func == null) return null;
 	if(func.funktion.returnType.type != DataType::UINT || func.funktion.returnType.indirection != 0) return null;
@@ -1713,8 +1711,8 @@ function Parser.type_check_delete_array_statement(stmt: Node*) {
 		var deconstructors = elementType.lookup_method(&deconstructorName);
 
 		if(deconstructors != null) {
-			var argTypes = new_vector();
-			var deconstructor = elementType.lookup_method_with_arguments(&deconstructorName, argTypes);
+			var argTypes: Vector;
+			var deconstructor = elementType.lookup_method_with_arguments(&deconstructorName, &argTypes);
 
 			if(deconstructor == null) {
 				stmt.print_position();
@@ -1754,12 +1752,12 @@ function Parser.type_check_return(stmt: Node*) {
 			var copyName: Name;
 			this.bind_name(&copyName, copyTok);
 
-			var args = new_vector();
+			var args: Vector;
 			var typePtr = copy_type(expectedType);
 			typePtr.indirection = 1;
 			args.push(typePtr);
 
-			var copy = expectedType.lookup_method_with_arguments(&copyName, args);
+			var copy = expectedType.lookup_method_with_arguments(&copyName, &args);
 
 			if(copy != null) {
 				stmt.ret.copyConstructor = true;
@@ -1770,7 +1768,7 @@ function Parser.type_check_return(stmt: Node*) {
 	stmt.ret.type = expectedType;
 
 	if(this.currentBlock.block.variables.size > 0) {
-		stmt.ret.variables = new_vector();
+		stmt.ret.variables = new Vector();
 		
 		var block = this.currentBlock;
 
@@ -1789,8 +1787,8 @@ function Parser.type_check_return(stmt: Node*) {
 				var deconstructors = variable.variable.type.lookup_method(&deconstructorName);
 
 				if(deconstructors != null) {
-					var argTypes = new_vector();
-					var deconstructor = variable.variable.type.lookup_method_with_arguments(&deconstructorName, argTypes);
+					var argTypes: Vector;
+					var deconstructor = variable.variable.type.lookup_method_with_arguments(&deconstructorName, &argTypes);
 
 					if(deconstructor == null) {
 						variable.print_position();
@@ -1869,7 +1867,7 @@ function Parser.type_check_statement(stmt: Node*) {
 	}
 
 	if(!temporaries.empty()) {
-		var temporariesToDeconstruct = new_vector();
+		var temporariesToDeconstruct = new Vector();
 
 		for(var i = 0; i < temporaries.size; ++i) {
 			var temp: Node* = temporaries.at(i);
@@ -1883,7 +1881,8 @@ function Parser.type_check_statement(stmt: Node*) {
 }
 
 function Parser.type_check_block(block: Node*) {
-	this.type_check_block(block, new_vector());
+	var vec = new Vector();
+	this.type_check_block(block, vec);
 }
 
 function Parser.type_check_block(block: Node*, variables: Vector*) {
@@ -1914,8 +1913,8 @@ function Parser.type_check_block(block: Node*, variables: Vector*) {
 		var deconstructors = stmt.variable.type.lookup_method(&deconstructorName);
 
 		if(deconstructors != null) {
-			var argTypes = new_vector();
-			var deconstructor = stmt.variable.type.lookup_method_with_arguments(&deconstructorName, argTypes);
+			var argTypes: Vector;
+			var deconstructor = stmt.variable.type.lookup_method_with_arguments(&deconstructorName, &argTypes);
 
 			if(deconstructor == null) {
 				stmt.print_position();
@@ -1935,7 +1934,7 @@ function Parser.type_check_function(funktion: Node*) {
 	if(!funktion.funktion.isMethod) {
 		var funcList = this.lookup_function(&funktion.funktion.name);
 
-		var paramTypes = new_vector();
+		var paramTypes = new Vector();
 		for(var i = 0; i < funktion.funktion.arguments.size; ++i) {
 			var arg: Node* = funktion.funktion.arguments.at(i);
 
@@ -1957,7 +1956,7 @@ function Parser.type_check_function(funktion: Node*) {
 	else {
 		var methodList = funktion.funktion.parentType.lookup_method(&funktion.funktion.name);
 
-		var paramTypes = new_vector();
+		var paramTypes = new Vector();
 		for(var i = 1; i < funktion.funktion.arguments.size; ++i) {
 			var arg: Node* = funktion.funktion.arguments.at(i);
 
@@ -1977,7 +1976,7 @@ function Parser.type_check_function(funktion: Node*) {
 		}
 	}
 
-	var arguments = new_vector();
+	var arguments = new Vector();
 
 	for(var i = 0; i < funktion.funktion.arguments.size; ++i) {
 		var arg: Node* = funktion.funktion.arguments.at(i);
@@ -1995,12 +1994,12 @@ function Parser.type_check_function(funktion: Node*) {
 			var copyName: Name;
 			this.bind_name(&copyName, copyTok);
 
-			var args = new_vector();
+			var args: Vector;
 			var typePtr = copy_type(arg.variable.type);
 			typePtr.indirection = 1;
 			args.push(typePtr);
 
-			var copy = arg.variable.type.lookup_method_with_arguments(&copyName, args);
+			var copy = arg.variable.type.lookup_method_with_arguments(&copyName, &args);
 
 			if(copy != null) {
 				arg.variable.copyConstructor = true;
@@ -2117,12 +2116,12 @@ function Parser.type_check_global_var(stmt: Node*) {
 			var copyName: Name;
 			this.bind_name(&copyName, copyTok);
 
-			var args = new_vector();
+			var args: Vector;
 			var typePtr = copy_type(declType);
 			typePtr.indirection = 1;
 			args.push(typePtr);
 
-			var copy = declType.lookup_method_with_arguments(&copyName, args);
+			var copy = declType.lookup_method_with_arguments(&copyName, &args);
 
 			if(copy != null) {
 				stmt.variable.copyConstructor = true;
@@ -2155,7 +2154,7 @@ function Parser.type_check_global_var(stmt: Node*) {
 			stmt.variable.arguments = null;
 		}
 		else {
-			var argTypes = new_vector();
+			var argTypes: Vector;
 			for(var i = 0; i < stmt.variable.arguments.size; ++i) {
 				var arg: Node* = stmt.variable.arguments.at(i);
 				this.type_check_expr(arg);
@@ -2164,18 +2163,18 @@ function Parser.type_check_global_var(stmt: Node*) {
 				argTypes.push(argType);
 			}
 
-			var constructor = stmt.variable.type.lookup_method_with_arguments(&constructorName, argTypes);
+			var constructor = stmt.variable.type.lookup_method_with_arguments(&constructorName, &argTypes);
 
 			if(constructor == null) {
 				stmt.print_position();
 				eputs("Failed to resolve constructor"); eputs(" of type "); eputsln(type_to_string(stmt.variable.type));
-				eputs("Given argument types: "); eput_argument_types(argTypes); eputln();
+				eputs("Given argument types: "); eput_argument_types(&argTypes); eputln();
 				exit(1);
 			}
 
 			var paramTypes = constructor.funktion.argTypes;
 			if(paramTypes == null) {
-				paramTypes = new_vector();
+				paramTypes = new Vector();
 				for(var i = 1; i < constructor.funktion.arguments.size; ++i) {
 					var type: Type* = (constructor.funktion.arguments.at(i) as Node*).variable.type;
 					resolve_type(type);
@@ -2196,9 +2195,9 @@ function Parser.type_check_global_var(stmt: Node*) {
 		var constructors = stmt.variable.type.lookup_method(&constructorName);
 
 		if(constructors != null) {
-			stmt.variable.arguments = new_vector();
+			stmt.variable.arguments = new Vector();
 			
-			var argTypes = new_vector();
+			var argTypes = new Vector();
 			var constructor = stmt.variable.type.lookup_method_with_arguments(&constructorName, argTypes);
 
 			if(constructor == null) {
@@ -2327,7 +2326,8 @@ function Parser.type_check_top_level_declaration(node: Node*) {
 
 function Parser.type_check(program: Node*) {
 	definedTypes = this.definedTypes;
-	namespaces = new_vector();
+	delete namespaces;
+	namespaces = new Vector();
 
 	for(var i = 0; i < program.block.children.size; ++i) {
 		var node: Node* = program.block.children.at(i);

--- a/src/typecheck.zpr
+++ b/src/typecheck.zpr
@@ -554,7 +554,7 @@ function assignment_op_to_node_type(op: int): int {
 
 function synthetic_binary_op(op: Token*, lhs: Node*, rhs: Node*): Node* {
 	var type = assignment_op_to_node_type(op.type);
-	var node = new_node(type, op);
+	var node = new Node(type, op);
 	node.binary.lhs = lhs;
 	node.binary.rhs = rhs;
 	return node;
@@ -648,7 +648,7 @@ function Parser.type_check_binary(expr: Node*) {
 	// With int <-> float, float always takes priority
 	else if((left.assignable(F64_TYPE) && right.assignable(INT_TYPE)) || (left.assignable(INT_TYPE) && right.assignable(F64_TYPE))) {
 		if(left.assignable(INT_TYPE)) {
-			var cast = new_node(NodeType::INT_TO_FLOAT, expr.binary.lhs.position);
+			var cast = new Node(NodeType::INT_TO_FLOAT, expr.binary.lhs.position);
 			cast.computedType = F64_TYPE;
 			cast.unary = expr.binary.lhs;
 			expr.binary.lhs = cast;
@@ -656,7 +656,7 @@ function Parser.type_check_binary(expr: Node*) {
 		}
 		// Right is an integer
 		else {
-			var cast = new_node(NodeType::INT_TO_FLOAT, expr.binary.rhs.position);
+			var cast = new Node(NodeType::INT_TO_FLOAT, expr.binary.rhs.position);
 			cast.computedType = F64_TYPE;
 			cast.unary = expr.binary.rhs;
 			expr.binary.rhs = cast;
@@ -957,13 +957,13 @@ function Parser.type_check_assign(expr: Node*) {
 	resolve_type(rhs);
 
 	if(lhs.is_integral() && rhs.is_float()) {
-		var cast = new_node(NodeType::FLOAT_TO_INT, expr.assignment.lhs.position);
+		var cast = new Node(NodeType::FLOAT_TO_INT, expr.assignment.lhs.position);
 		cast.computedType = INT_TYPE;
 		cast.unary = expr.assignment.rhs;
 		expr.assignment.rhs = cast;
 	}
 	else if(lhs.is_float() && rhs.is_integral()) {
-		var cast = new_node(NodeType::INT_TO_FLOAT, expr.assignment.lhs.position);
+		var cast = new Node(NodeType::INT_TO_FLOAT, expr.assignment.lhs.position);
 		cast.computedType = INT_TYPE;
 		cast.unary = expr.assignment.rhs;
 		expr.assignment.rhs = cast;
@@ -990,7 +990,7 @@ function Parser.type_check_assign(expr: Node*) {
 			var copy = lhs.lookup_method_with_arguments(&copyName, &args);
 
 			if(copy != null) {
-				var overload = new_node(NodeType::OVERLOAD, expr.position);
+				var overload = new Node(NodeType::OVERLOAD, expr.position);
 				overload.overload.value = expr.assignment.rhs;
 				overload.overload.lhsType = lhs;
 				overload.overload.rhsType = typePtr;
@@ -1333,13 +1333,13 @@ function Parser.type_check_define_var(stmt: Node*) {
 		resolve_type(valueType);
 
 		if(declType.is_integral() && valueType.is_float()) {
-			var cast = new_node(NodeType::FLOAT_TO_INT, stmt.position);
+			var cast = new Node(NodeType::FLOAT_TO_INT, stmt.position);
 			cast.computedType = INT_TYPE;
 			cast.unary = stmt.variable.value;
 			stmt.variable.value = cast;
 		}
 		else if(declType.is_float() && valueType.is_integral()) {
-			var cast = new_node(NodeType::INT_TO_FLOAT, stmt.position);
+			var cast = new Node(NodeType::INT_TO_FLOAT, stmt.position);
 			cast.computedType = INT_TYPE;
 			cast.unary = stmt.variable.value;
 			stmt.variable.value = cast;
@@ -1661,7 +1661,7 @@ function Parser.resolve_get_array_length_function(): Node* {
 	var funcName: Name;
 	this.bind_name(&funcName, funcTok);
 
-	var nameSpace = new_namespace(null, null);
+	var nameSpace = new Namespace(null, null);
 	nameSpace.parts = new Vector();
 
 	nameSpace.parts.push(synthetic_token(TokenType::IDENTIFIER, "std"));
@@ -2036,7 +2036,7 @@ function Parser.type_check_function(funktion: Node*) {
 	if(!funktion.funktion.body.block.hasReturned) {
 		if(funktion.funktion.returnType.is_void()) {
 			var tok = synthetic_token(TokenType::RETURN, "return");
-			var implReturn = new_node(NodeType::RETURN, tok);
+			var implReturn = new Node(NodeType::RETURN, tok);
 
 			this.currentBlock = funktion.funktion.body;
 			this.type_check_return(implReturn);
@@ -2092,13 +2092,13 @@ function Parser.type_check_global_var(stmt: Node*) {
 		resolve_type(valueType);
 
 		if(declType.is_integral() && valueType.is_float()) {
-			var cast = new_node(NodeType::FLOAT_TO_INT, stmt.position);
+			var cast = new Node(NodeType::FLOAT_TO_INT, stmt.position);
 			cast.computedType = INT_TYPE;
 			cast.unary = stmt.variable.value;
 			stmt.variable.value = cast;
 		}
 		else if(declType.is_float() && valueType.is_integral()) {
-			var cast = new_node(NodeType::INT_TO_FLOAT, stmt.position);
+			var cast = new Node(NodeType::INT_TO_FLOAT, stmt.position);
 			cast.computedType = INT_TYPE;
 			cast.unary = stmt.variable.value;
 			stmt.variable.value = cast;

--- a/src/types.zpr
+++ b/src/types.zpr
@@ -1,5 +1,29 @@
 import "src/ast.zpr";
 
+var __allTypes: Vector* = null;
+
+function Type.constructor() {
+	if(__allTypes == null) {
+		__allTypes = new Vector;
+	}
+	__allTypes.push(this);
+	this.fields = null;
+	this.methods = null;
+}
+
+function free_types() {
+	if(__allTypes == null) return;
+	for(var i = 0; i < __allTypes.size; ++i) {
+		var type: Type* = __allTypes.at(i);
+		if(type.fields != null)
+			delete type.fields;
+		if(type.methods != null)
+			delete type.methods;
+		delete type;
+	}
+	delete __allTypes;
+}
+
 var INT_TYPE: Type*;
 var UINT_TYPE: Type*;
 var I8_TYPE: Type*;

--- a/src/types.zpr
+++ b/src/types.zpr
@@ -9,14 +9,8 @@ var VOID_TYPE: Type*;
 var ANY_TYPE: Type*;
 var ANYP_TYPE: Type*;
 
-function new_type(): Type* {
-	var type: Type* = malloc(sizeof(Type));
-
-	return type;
-}
-
 function copy_type(a: Type*): Type* {
-	var copy: Type* = malloc(sizeof(Type));
+	var copy = new Type;
 	copy.type = a.type;
 	copy.indirection = a.indirection;
 	copy.name = a.name;
@@ -26,29 +20,29 @@ function copy_type(a: Type*): Type* {
 }
 
 function build_types() {
-	INT_TYPE = new_type();
+	INT_TYPE = new Type;
 	INT_TYPE.type = DataType::INT;
 
-	UINT_TYPE = new_type();
+	UINT_TYPE = new Type;
 	UINT_TYPE.type = DataType::UINT;
 
-	I8_TYPE = new_type();
+	I8_TYPE = new Type;
 	I8_TYPE.type = DataType::I8;
 
-	STR_TYPE = new_type();
+	STR_TYPE = new Type;
 	STR_TYPE.type = DataType::I8;
 	STR_TYPE.indirection = 1;
 
-	F64_TYPE = new_type();
+	F64_TYPE = new Type;
 	F64_TYPE.type = DataType::F64;
 
-	VOID_TYPE = new_type();
+	VOID_TYPE = new Type;
 	VOID_TYPE.type = DataType::VOID;
 
-	ANY_TYPE = new_type();
+	ANY_TYPE = new Type;
 	ANY_TYPE.type = DataType::ANY;
 
-	ANYP_TYPE = new_type();
+	ANYP_TYPE = new Type;
 	ANYP_TYPE.type = DataType::ANY;
 	ANYP_TYPE.indirection = 1;
 }

--- a/std/image.zpr
+++ b/std/image.zpr
@@ -14,12 +14,23 @@ namespace std::image {
 		data: Color8*;
 	}
 
-	function new_ppm_img(width: u32, height: u32): PPMImage* {
-		var img: PPMImage* = malloc(sizeof(PPMImage));
-		img.width = width;
-		img.height = height;
-		img.data = malloc(width * height * sizeof(Color8));
-		return img;
+	function PPMImage.constructor(width: u32, height: u32) {
+		this.width = width;
+		this.height = height;
+		this.data = new Color8[width * height];
+	}
+
+	function PPMImage.copy(other: PPMImage*) {
+		this.width = other.width;
+		this.height = other.height;
+		this.data = new Color8[this.width * this.height];
+		for(var i = 0; i < this.width * this.height; ++i) {
+			this.data[i] = other.data[i];
+		}
+	}
+
+	function PPMImage.deconstructor() {
+		delete[] this.data;
 	}
 
 	function PPMImage.set_pixel(x: u32, y: u32, color: Color8*) {

--- a/std/io.zpr
+++ b/std/io.zpr
@@ -164,11 +164,11 @@ function fopen(name: i8*, mode: i8): File* {
 	else if(mode == 'r') openMode = O_RDONLY;
 	else return null;
 
-	var f: File* = malloc(sizeof(File));
+	var f: File* = new File;
 	f.name = name;
 	f.fd = open(name, openMode, 438); // 0o666
 	if(f.fd < 0) {
-		free(f);
+		delete f;
 		return null;
 	}
 	return f;
@@ -291,7 +291,7 @@ function File.size(): int {
 
 function File.slurp(sizeptr: int*): i8* {
 	var size = this.size();
-	var text: i8* = malloc(size + 1);
+	var text: i8* = new i8[size + 1];
 	this.read(text, size);
 	text[size] = 0;
 	if(sizeptr as int) *sizeptr = size;

--- a/std/vector.zpr
+++ b/std/vector.zpr
@@ -48,13 +48,16 @@ function Vector.at(index: int): any* {
 function Vector.push(item: any*) {
 	if(this.size == this.capacity) {
 		var newCapacity = this.capacity * 2;
-		var newData = malloc(newCapacity * sizeof(any*));
+		var newData = new any*[newCapacity];
 		memcpy(newData, this.data, this.capacity * sizeof(any*));
+
+		delete[] this.data;
+
 		this.data = newData;
 		this.capacity = newCapacity;
 	}
 	this.data[this.size] = item;
-	this.size = this.size + 1;
+	++this.size;
 }
 
 function Vector.pop(): any* {

--- a/std/vector.zpr
+++ b/std/vector.zpr
@@ -7,17 +7,30 @@ struct Vector {
 	data: any**;
 }
 
-function new_vector_sized(capacity: int): Vector* {
-	var vec: Vector* = malloc(sizeof(Vector));
-	vec.size = 0;
-	vec.capacity = capacity;
-	vec.data = malloc(capacity * sizeof(any*));
-	return vec;
+function Vector.constructor() {
+	this.size = 0;
+	this.capacity = 8;
+	this.data = new any*[this.capacity];
 }
 
-function new_vector(): Vector* {
-	// Initial capacity
-	return new_vector_sized(8);
+function Vector.constructor(initialCapacity: uint) {
+	this.size = 0;
+	this.capacity = initialCapacity;
+	this.data = new any*[this.capacity];
+}
+
+function Vector.copy(other: Vector*) {
+	this.size = other.size;
+	this.capacity = other.capacity;
+	this.data = new any*[this.capacity];
+
+	for(var i = 0; i < this.capacity; ++i) {
+		this.data[i] = other.data[i];
+	}
+}
+
+function Vector.deconstructor() {
+	delete[] this.data;
 }
 
 function Vector.empty(): bool {


### PR DESCRIPTION
# Description
This PR changes the memory-management of the compiler to use the `new/delete` and `constructor/deconstructor` mechanisms. The compiler also now frees all tokens, types, and nodes allocated.

There is no observable change to the compiler nor the language.