### PR TITLE
Add Null Checks to Delete Statements

### DIFF
--- a/bootstrap/bootstrap_x86_64_linux.yasm
+++ b/bootstrap/bootstrap_x86_64_linux.yasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:86145b65a07d46743ae1c87cce2864711ad96fd28fb14197676e79b5bdeebce3
-size 971958
+oid sha256:4e6e82fe820bf8621231224f400ff30c588d29a3c79fd4575b54f3095c0e83ea
+size 973409

--- a/src/ast.zpr
+++ b/src/ast.zpr
@@ -313,9 +313,7 @@ function Node.constructor(type: int, position: Token*) {
 }
 
 function Node.deconstructor() {
-	if(this.temporaries != null) {
-		delete this.temporaries;
-	}
+	delete this.temporaries;
 	
 	when(this.type) {
 		NodeType::FLOAT_LITERAL -> {
@@ -336,10 +334,8 @@ function Node.deconstructor() {
 		}
 		NodeType::DEFINE_VAR, NodeType::DEFINE_GLOBAL_VAR -> {
 			this.variable.name.deconstructor();
-			if(this.variable.arguments != null)
-				delete this.variable.arguments;
-			if(this.variable.argTypes != null)
-				delete this.variable.argTypes;
+			delete this.variable.arguments;
+			delete this.variable.argTypes;
 		}
 		NodeType::ACCESS_VAR, NodeType::ACCESS_GLOBAL_VAR -> {
 			this.variable.name.deconstructor();
@@ -351,10 +347,8 @@ function Node.deconstructor() {
 			delete this.block.children;
 		}
 		NodeType::NEW -> {
-			if(this.constructor.argTypes != null)
-				delete this.constructor.argTypes;
-			if(this.constructor.arguments != null)
-				delete this.constructor.arguments;
+			delete this.constructor.argTypes;
+			delete this.constructor.arguments;
 		}
 		NodeType::WHEN -> {
 			delete this.vhen.branches;
@@ -365,16 +359,14 @@ function Node.deconstructor() {
 		NodeType::FUNCTION -> {
 			this.funktion.name.deconstructor();
 			delete this.funktion.arguments;
-			if(this.funktion.argTypes != null)
-				delete this.funktion.argTypes;
+			delete this.funktion.argTypes;
 		}
 		NodeType::NAMESPACE -> {
 			delete this.nameSpace.name;
 		}
 		NodeType::BLOCK -> {
 			delete this.block.children;
-			if(this.block.variables != null)
-				delete this.block.variables;
+			delete this.block.variables;
 		}
 		NodeType::PROGRAM -> {
 			delete this.block.children;
@@ -397,13 +389,11 @@ function Name.init(namespaceName: Namespace*, name: Token*) {
 }
 
 function Name.deconstructor() {
-	if(this.namespaceName != null)
-		delete this.namespaceName;
+	delete this.namespaceName;
 }
 
 function Namespace.deconstructor() {
-	if(this.parts != null)
-		delete this.parts;
+	delete this.parts;
 }
 
 function Name.fput(fd: int) {

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -1175,7 +1175,13 @@ function generate_define_var(stmt: Node*, out: File*) {
 }
 
 function generate_delete(stmt: Node*, out: File*) {
+	var nullLabel = ++labelCount;
+
 	generate_expr(stmt.deconstructor.value, out);
+
+	out.putsln("    test rax, rax");
+	out.puts("    jz .l"); out.putd(nullLabel); out.putln();
+
 	out.putsln("    mov rdi, rax");
 	out.putsln("    call _FAPZfree");
 
@@ -1190,6 +1196,8 @@ function generate_delete(stmt: Node*, out: File*) {
 			out.puts("    call _M"); out.put_name(&stmt.unary.computedType.name); out.puts("_"); out.put_name(&deconstructorName); out.putln();
 		}
 	}
+
+	out.puts(".l"); out.putd(nullLabel); out.putsln(":");
 }
 
 function generate_delete_array(stmt: Node*, out: File*) {

--- a/src/codegen.zpr
+++ b/src/codegen.zpr
@@ -1201,7 +1201,12 @@ function generate_delete(stmt: Node*, out: File*) {
 }
 
 function generate_delete_array(stmt: Node*, out: File*) {
+	var nullLabel = ++labelCount;
+
 	generate_expr(stmt.deconstructor.value, out);
+
+	out.putsln("    test rax, rax");
+	out.puts("    jz .l"); out.putd(nullLabel); out.putln();
 
 	if(stmt.deconstructor.shouldDeconstruct) {
 		out.putsln("push rax");
@@ -1265,6 +1270,8 @@ function generate_delete_array(stmt: Node*, out: File*) {
 	
 	out.putsln("    mov rdi, rax");
 	out.putsln("    call _FAPZfree");
+
+	out.puts(".l"); out.putd(nullLabel); out.putsln(":");
 }
 
 function generate_return(stmt: Node*, out: File*) {

--- a/src/types.zpr
+++ b/src/types.zpr
@@ -15,10 +15,8 @@ function free_types() {
 	if(__allTypes == null) return;
 	for(var i = 0; i < __allTypes.size; ++i) {
 		var type: Type* = __allTypes.at(i);
-		if(type.fields != null)
-			delete type.fields;
-		if(type.methods != null)
-			delete type.methods;
+		delete type.fields;
+		delete type.methods;
 		delete type;
 	}
 	delete __allTypes;

--- a/std/map.zpr
+++ b/std/map.zpr
@@ -29,9 +29,7 @@ namespace std::map {
 	function HashMap.deconstructor() {
 		for(var i = 0; i < this.capacity; ++i) {
 			var item = this.items[i];
-			if(item.key != null) {
-				delete item.key;
-			}
+			delete item.key;
 		}
 		delete[] this.items;
 	}


### PR DESCRIPTION
# Description
Fixes the issue (#27) detailing how delete should react to `null` pointers. Using `delete` (and `delete[]`) on a pointer with a `null` value will now act as a no-op.

# Related Issues

Fixes #27 